### PR TITLE
1.16.210 update

### DIFF
--- a/data/1.16.210/protocol.json
+++ b/data/1.16.210/protocol.json
@@ -1543,6 +1543,10 @@
           "type": "string"
         },
         {
+          "name": "play_fab_id",
+          "type": "string"
+        },
+        {
           "name": "skin_resource_pack",
           "type": "string"
         },

--- a/data/1.16.210/protocol.json
+++ b/data/1.16.210/protocol.json
@@ -744,80 +744,62 @@
         ]
       }
     ],
-    "Transaction": [
+    "TransactionUseItem": [
       "container",
       [
         {
-          "name": "legacy_request_id",
-          "type": "zigzag32"
-        },
-        {
-          "name": "legacy_transactions",
-          "type": [
-            "switch",
-            {
-              "compareTo": "legacy_request_id",
-              "fields": {
-                "0": "void"
-              },
-              "default": [
-                "array",
-                {
-                  "countType": "varint",
-                  "type": [
-                    "container",
-                    [
-                      {
-                        "name": "container_id",
-                        "type": "u8"
-                      },
-                      {
-                        "name": "changed_slots",
-                        "type": [
-                          "array",
-                          {
-                            "countType": "varint",
-                            "type": [
-                              "container",
-                              [
-                                {
-                                  "name": "slot_id",
-                                  "type": "u8"
-                                }
-                              ]
-                            ]
-                          }
-                        ]
-                      }
-                    ]
-                  ]
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "name": "transaction_type",
+          "name": "action_type",
           "type": [
             "mapper",
             {
               "type": "varint",
               "mappings": {
-                "0": "normal",
-                "1": "inventory_mismatch",
-                "2": "item_use",
-                "3": "item_use_on_entity",
-                "4": "item_release"
+                "0": "click_block",
+                "1": "click_air",
+                "2": "break_block"
               }
             }
           ]
         },
         {
+          "name": "block_position",
+          "type": "BlockCoordinates"
+        },
+        {
+          "name": "face",
+          "type": "varint"
+        },
+        {
+          "name": "hotbar_slot",
+          "type": "varint"
+        },
+        {
+          "name": "held_item",
+          "type": "Item"
+        },
+        {
+          "name": "player_pos",
+          "type": "vec3f"
+        },
+        {
+          "name": "click_pos",
+          "type": "vec3f"
+        },
+        {
+          "name": "block_runtime_id",
+          "type": "varint"
+        }
+      ]
+    ],
+    "TransactionActions": [
+      "container",
+      [
+        {
           "name": "network_ids",
           "type": "bool"
         },
         {
-          "name": "inventory_actions",
+          "name": "actions",
           "type": [
             "array",
             {
@@ -928,6 +910,89 @@
               ]
             }
           ]
+        }
+      ]
+    ],
+    "TransactionLegacy": [
+      "container",
+      [
+        {
+          "name": "legacy_request_id",
+          "type": "zigzag32"
+        },
+        {
+          "name": "legacy_transactions",
+          "type": [
+            "switch",
+            {
+              "compareTo": "legacy_request_id",
+              "fields": {
+                "0": "void"
+              },
+              "default": [
+                "array",
+                {
+                  "countType": "varint",
+                  "type": [
+                    "container",
+                    [
+                      {
+                        "name": "container_id",
+                        "type": "u8"
+                      },
+                      {
+                        "name": "changed_slots",
+                        "type": [
+                          "array",
+                          {
+                            "countType": "varint",
+                            "type": [
+                              "container",
+                              [
+                                {
+                                  "name": "slot_id",
+                                  "type": "u8"
+                                }
+                              ]
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    ],
+    "Transaction": [
+      "container",
+      [
+        {
+          "name": "legacy",
+          "type": "TransactionLegacy"
+        },
+        {
+          "name": "transaction_type",
+          "type": [
+            "mapper",
+            {
+              "type": "varint",
+              "mappings": {
+                "0": "normal",
+                "1": "inventory_mismatch",
+                "2": "item_use",
+                "3": "item_use_on_entity",
+                "4": "item_release"
+              }
+            }
+          ]
+        },
+        {
+          "name": "actions",
+          "type": "TransactionActions"
         },
         {
           "name": "transaction_data",
@@ -938,53 +1003,7 @@
               "fields": {
                 "normal": "void",
                 "inventory_mismatch": "void",
-                "item_use": [
-                  "container",
-                  [
-                    {
-                      "name": "action_type",
-                      "type": [
-                        "mapper",
-                        {
-                          "type": "varint",
-                          "mappings": {
-                            "0": "click_block",
-                            "1": "click_air",
-                            "2": "break_block"
-                          }
-                        }
-                      ]
-                    },
-                    {
-                      "name": "block_position",
-                      "type": "BlockCoordinates"
-                    },
-                    {
-                      "name": "face",
-                      "type": "varint"
-                    },
-                    {
-                      "name": "hotbar_slot",
-                      "type": "varint"
-                    },
-                    {
-                      "name": "held_item",
-                      "type": "Item"
-                    },
-                    {
-                      "name": "player_pos",
-                      "type": "vec3f"
-                    },
-                    {
-                      "name": "click_pos",
-                      "type": "vec3f"
-                    },
-                    {
-                      "name": "block_runtime_id",
-                      "type": "varint"
-                    }
-                  ]
-                ],
+                "item_use": "TransactionUseItem",
                 "item_use_on_entity": [
                   "container",
                   [
@@ -2009,6 +2028,42 @@
         ]
       }
     ],
+    "Action": [
+      "mapper",
+      {
+        "type": "zigzag32",
+        "mappings": {
+          "0": "start_break",
+          "1": "abort_break",
+          "2": "stop_break",
+          "3": "get_updated_block",
+          "4": "drop_item",
+          "5": "start_sleeping",
+          "6": "stop_sleeping",
+          "7": "respawn",
+          "8": "jump",
+          "9": "start_sprint",
+          "10": "stop_sprint",
+          "11": "start_sneak",
+          "12": "stop_sneak",
+          "13": "creative_player_destroy_block",
+          "14": "dimension_change_ack",
+          "15": "start_glide",
+          "16": "stop_glide",
+          "17": "build_denied",
+          "18": "crack_break",
+          "19": "change_skin",
+          "20": "set_enchatnment_seed",
+          "21": "swimming",
+          "22": "stop_swimming",
+          "23": "start_spin_attack",
+          "24": "stop_spin_attack",
+          "25": "ineract_block",
+          "26": "predict_break",
+          "27": "continue_break"
+        }
+      }
+    ],
     "StackRequestSlotInfo": [
       "container",
       [
@@ -2026,272 +2081,266 @@
         }
       ]
     ],
-    "ItemStackRequests": [
-      "array",
-      {
-        "countType": "varint",
-        "type": [
-          "container",
-          [
+    "ItemStackRequest": [
+      "container",
+      [
+        {
+          "name": "request_id",
+          "type": "zigzag32"
+        },
+        {
+          "name": "actions",
+          "type": [
+            "array",
             {
-              "name": "request_id",
-              "type": "zigzag32"
-            },
-            {
-              "name": "actions",
+              "countType": "varint",
               "type": [
-                "array",
-                {
-                  "countType": "varint",
-                  "type": [
-                    "container",
-                    [
+                "container",
+                [
+                  {
+                    "name": "type_id",
+                    "type": [
+                      "mapper",
                       {
-                        "name": "type_id",
-                        "type": [
-                          "mapper",
-                          {
-                            "type": "u8",
-                            "mappings": {
-                              "0": "take",
-                              "1": "place",
-                              "2": "swap",
-                              "3": "drop",
-                              "4": "destroy",
-                              "5": "consume",
-                              "6": "create",
-                              "7": "lab_table_combine",
-                              "8": "beacon_payment",
-                              "9": "mine_block",
-                              "10": "craft_recipe",
-                              "11": "craft_recipe_auto",
-                              "12": "craft_creative",
-                              "13": "optional",
-                              "14": "non_implemented",
-                              "15": "results_deprecated"
-                            }
-                          }
-                        ]
-                      },
-                      {
-                        "anon": true,
-                        "type": [
-                          "switch",
-                          {
-                            "compareTo": "type_id",
-                            "fields": {
-                              "take": [
-                                "container",
-                                [
-                                  {
-                                    "name": "count",
-                                    "type": "u8"
-                                  },
-                                  {
-                                    "name": "source",
-                                    "type": "StackRequestSlotInfo"
-                                  },
-                                  {
-                                    "name": "destination",
-                                    "type": "StackRequestSlotInfo"
-                                  }
-                                ]
-                              ],
-                              "place": [
-                                "container",
-                                [
-                                  {
-                                    "name": "count",
-                                    "type": "u8"
-                                  },
-                                  {
-                                    "name": "source",
-                                    "type": "StackRequestSlotInfo"
-                                  },
-                                  {
-                                    "name": "destination",
-                                    "type": "StackRequestSlotInfo"
-                                  }
-                                ]
-                              ],
-                              "swap": [
-                                "container",
-                                [
-                                  {
-                                    "name": "source",
-                                    "type": "StackRequestSlotInfo"
-                                  },
-                                  {
-                                    "name": "destination",
-                                    "type": "StackRequestSlotInfo"
-                                  }
-                                ]
-                              ],
-                              "drop": [
-                                "container",
-                                [
-                                  {
-                                    "name": "count",
-                                    "type": "u8"
-                                  },
-                                  {
-                                    "name": "source",
-                                    "type": "StackRequestSlotInfo"
-                                  },
-                                  {
-                                    "name": "randomly",
-                                    "type": "bool"
-                                  }
-                                ]
-                              ],
-                              "destroy": [
-                                "container",
-                                [
-                                  {
-                                    "name": "count",
-                                    "type": "u8"
-                                  },
-                                  {
-                                    "name": "source",
-                                    "type": "StackRequestSlotInfo"
-                                  }
-                                ]
-                              ],
-                              "consume": [
-                                "container",
-                                [
-                                  {
-                                    "name": "count",
-                                    "type": "u8"
-                                  },
-                                  {
-                                    "name": "source",
-                                    "type": "StackRequestSlotInfo"
-                                  }
-                                ]
-                              ],
-                              "create": [
-                                "container",
-                                [
-                                  {
-                                    "name": "result_slot_id",
-                                    "type": "u8"
-                                  }
-                                ]
-                              ],
-                              "beacon_payment": [
-                                "container",
-                                [
-                                  {
-                                    "name": "primary_effect",
-                                    "type": "zigzag32"
-                                  },
-                                  {
-                                    "name": "secondary_effect",
-                                    "type": "zigzag32"
-                                  }
-                                ]
-                              ],
-                              "mine_block": [
-                                "container",
-                                [
-                                  {
-                                    "name": "unknown1",
-                                    "type": "zigzag32"
-                                  },
-                                  {
-                                    "name": "predicted_durability",
-                                    "type": "zigzag32"
-                                  },
-                                  {
-                                    "name": "network_id",
-                                    "type": "zigzag32"
-                                  }
-                                ]
-                              ],
-                              "craft_recipe": [
-                                "container",
-                                [
-                                  {
-                                    "name": "recipe_network_id",
-                                    "type": "varint"
-                                  }
-                                ]
-                              ],
-                              "craft_recipe_auto": [
-                                "container",
-                                [
-                                  {
-                                    "name": "recipe_network_id",
-                                    "type": "varint"
-                                  }
-                                ]
-                              ],
-                              "craft_creative": [
-                                "container",
-                                [
-                                  {
-                                    "name": "creative_item_network_id",
-                                    "type": "varint32"
-                                  }
-                                ]
-                              ],
-                              "optional": [
-                                "container",
-                                [
-                                  {
-                                    "name": "recipe_network_id",
-                                    "type": "varint"
-                                  },
-                                  {
-                                    "name": "filtered_string_index",
-                                    "type": "li32"
-                                  }
-                                ]
-                              ],
-                              "non_implemented": "void",
-                              "results_deprecated": [
-                                "container",
-                                [
-                                  {
-                                    "name": "result_items",
-                                    "type": [
-                                      "array",
-                                      {
-                                        "countType": "varint",
-                                        "type": "Item"
-                                      }
-                                    ]
-                                  },
-                                  {
-                                    "name": "times_crafted",
-                                    "type": "u8"
-                                  }
-                                ]
-                              ]
-                            },
-                            "default": "void"
-                          }
-                        ]
+                        "type": "u8",
+                        "mappings": {
+                          "0": "take",
+                          "1": "place",
+                          "2": "swap",
+                          "3": "drop",
+                          "4": "destroy",
+                          "5": "consume",
+                          "6": "create",
+                          "7": "lab_table_combine",
+                          "8": "beacon_payment",
+                          "9": "mine_block",
+                          "10": "craft_recipe",
+                          "11": "craft_recipe_auto",
+                          "12": "craft_creative",
+                          "13": "optional",
+                          "14": "non_implemented",
+                          "15": "results_deprecated"
+                        }
                       }
                     ]
-                  ]
-                }
-              ]
-            },
-            {
-              "name": "custom_names",
-              "type": [
-                "array",
-                {
-                  "countType": "varint",
-                  "type": "string"
-                }
+                  },
+                  {
+                    "anon": true,
+                    "type": [
+                      "switch",
+                      {
+                        "compareTo": "type_id",
+                        "fields": {
+                          "take": [
+                            "container",
+                            [
+                              {
+                                "name": "count",
+                                "type": "u8"
+                              },
+                              {
+                                "name": "source",
+                                "type": "StackRequestSlotInfo"
+                              },
+                              {
+                                "name": "destination",
+                                "type": "StackRequestSlotInfo"
+                              }
+                            ]
+                          ],
+                          "place": [
+                            "container",
+                            [
+                              {
+                                "name": "count",
+                                "type": "u8"
+                              },
+                              {
+                                "name": "source",
+                                "type": "StackRequestSlotInfo"
+                              },
+                              {
+                                "name": "destination",
+                                "type": "StackRequestSlotInfo"
+                              }
+                            ]
+                          ],
+                          "swap": [
+                            "container",
+                            [
+                              {
+                                "name": "source",
+                                "type": "StackRequestSlotInfo"
+                              },
+                              {
+                                "name": "destination",
+                                "type": "StackRequestSlotInfo"
+                              }
+                            ]
+                          ],
+                          "drop": [
+                            "container",
+                            [
+                              {
+                                "name": "count",
+                                "type": "u8"
+                              },
+                              {
+                                "name": "source",
+                                "type": "StackRequestSlotInfo"
+                              },
+                              {
+                                "name": "randomly",
+                                "type": "bool"
+                              }
+                            ]
+                          ],
+                          "destroy": [
+                            "container",
+                            [
+                              {
+                                "name": "count",
+                                "type": "u8"
+                              },
+                              {
+                                "name": "source",
+                                "type": "StackRequestSlotInfo"
+                              }
+                            ]
+                          ],
+                          "consume": [
+                            "container",
+                            [
+                              {
+                                "name": "count",
+                                "type": "u8"
+                              },
+                              {
+                                "name": "source",
+                                "type": "StackRequestSlotInfo"
+                              }
+                            ]
+                          ],
+                          "create": [
+                            "container",
+                            [
+                              {
+                                "name": "result_slot_id",
+                                "type": "u8"
+                              }
+                            ]
+                          ],
+                          "beacon_payment": [
+                            "container",
+                            [
+                              {
+                                "name": "primary_effect",
+                                "type": "zigzag32"
+                              },
+                              {
+                                "name": "secondary_effect",
+                                "type": "zigzag32"
+                              }
+                            ]
+                          ],
+                          "mine_block": [
+                            "container",
+                            [
+                              {
+                                "name": "unknown1",
+                                "type": "zigzag32"
+                              },
+                              {
+                                "name": "predicted_durability",
+                                "type": "zigzag32"
+                              },
+                              {
+                                "name": "network_id",
+                                "type": "zigzag32"
+                              }
+                            ]
+                          ],
+                          "craft_recipe": [
+                            "container",
+                            [
+                              {
+                                "name": "recipe_network_id",
+                                "type": "varint"
+                              }
+                            ]
+                          ],
+                          "craft_recipe_auto": [
+                            "container",
+                            [
+                              {
+                                "name": "recipe_network_id",
+                                "type": "varint"
+                              }
+                            ]
+                          ],
+                          "craft_creative": [
+                            "container",
+                            [
+                              {
+                                "name": "creative_item_network_id",
+                                "type": "varint32"
+                              }
+                            ]
+                          ],
+                          "optional": [
+                            "container",
+                            [
+                              {
+                                "name": "recipe_network_id",
+                                "type": "varint"
+                              },
+                              {
+                                "name": "filtered_string_index",
+                                "type": "li32"
+                              }
+                            ]
+                          ],
+                          "non_implemented": "void",
+                          "results_deprecated": [
+                            "container",
+                            [
+                              {
+                                "name": "result_items",
+                                "type": [
+                                  "array",
+                                  {
+                                    "countType": "varint",
+                                    "type": "Item"
+                                  }
+                                ]
+                              },
+                              {
+                                "name": "times_crafted",
+                                "type": "u8"
+                              }
+                            ]
+                          ]
+                        },
+                        "default": "void"
+                      }
+                    ]
+                  }
+                ]
               ]
             }
           ]
-        ]
-      }
+        },
+        {
+          "name": "custom_names",
+          "type": [
+            "array",
+            {
+              "countType": "varint",
+              "type": "string"
+            }
+          ]
+        }
+      ]
     ],
     "ItemStackResponses": [
       "array",
@@ -4481,42 +4530,7 @@
         },
         {
           "name": "action",
-          "type": [
-            "mapper",
-            {
-              "type": "zigzag32",
-              "mappings": {
-                "0": "start_break",
-                "1": "abort_break",
-                "2": "stop_break",
-                "3": "get_updated_block",
-                "4": "drop_item",
-                "5": "start_sleeping",
-                "6": "stop_sleeping",
-                "7": "respawn",
-                "8": "jump",
-                "9": "start_sprint",
-                "10": "stop_sprint",
-                "11": "start_sneak",
-                "12": "stop_sneak",
-                "13": "creative_player_destroy_block",
-                "14": "dimension_change_ack",
-                "15": "start_glide",
-                "16": "stop_glide",
-                "17": "build_denied",
-                "18": "crack_break",
-                "19": "change_skin",
-                "20": "set_enchatnment_seed",
-                "21": "swimming",
-                "22": "stop_swimming",
-                "23": "start_spin_attack",
-                "24": "stop_spin_attack",
-                "25": "ineract_block",
-                "26": "predict_break",
-                "27": "continue_break"
-              }
-            }
-          ]
+          "type": "Action"
         },
         {
           "name": "position",
@@ -6821,10 +6835,11 @@
             {
               "type": "varint",
               "mappings": {
-                "0": "mouse",
-                "1": "touch",
-                "2": "game_pad",
-                "3": "motion_controller"
+                "0": "unknown",
+                "1": "mouse",
+                "2": "touch",
+                "3": "game_pad",
+                "4": "motion_controller"
               }
             }
           ]
@@ -6870,6 +6885,152 @@
         {
           "name": "delta",
           "type": "vec3f"
+        },
+        {
+          "name": "transaction",
+          "type": [
+            "switch",
+            {
+              "compareTo": "input_data.item_interact",
+              "fields": {
+                "true": [
+                  "container",
+                  [
+                    {
+                      "name": "legacy",
+                      "type": "TransactionLegacy"
+                    },
+                    {
+                      "name": "actions",
+                      "type": "TransactionActions"
+                    },
+                    {
+                      "name": "data",
+                      "type": "TransactionUseItem"
+                    }
+                  ]
+                ]
+              },
+              "default": "void"
+            }
+          ]
+        },
+        {
+          "name": "item_stack_request",
+          "type": [
+            "switch",
+            {
+              "compareTo": "input_data.item_stack_request",
+              "fields": {
+                "true": "ItemStackRequest"
+              },
+              "default": "void"
+            }
+          ]
+        },
+        {
+          "name": "block_action",
+          "type": [
+            "switch",
+            {
+              "compareTo": "input_data.block_action",
+              "fields": {
+                "true": [
+                  "array",
+                  {
+                    "countType": "zigzag32",
+                    "type": [
+                      "container",
+                      [
+                        {
+                          "name": "action",
+                          "type": "Action"
+                        },
+                        {
+                          "anon": true,
+                          "type": [
+                            "switch",
+                            {
+                              "compareTo": "action",
+                              "fields": {
+                                "start_break": [
+                                  "container",
+                                  [
+                                    {
+                                      "name": "position",
+                                      "type": "BlockCoordinates"
+                                    },
+                                    {
+                                      "name": "face",
+                                      "type": "zigzag32"
+                                    }
+                                  ]
+                                ],
+                                "abort_break": [
+                                  "container",
+                                  [
+                                    {
+                                      "name": "position",
+                                      "type": "BlockCoordinates"
+                                    },
+                                    {
+                                      "name": "face",
+                                      "type": "zigzag32"
+                                    }
+                                  ]
+                                ],
+                                "crack_break": [
+                                  "container",
+                                  [
+                                    {
+                                      "name": "position",
+                                      "type": "BlockCoordinates"
+                                    },
+                                    {
+                                      "name": "face",
+                                      "type": "zigzag32"
+                                    }
+                                  ]
+                                ],
+                                "predict_break": [
+                                  "container",
+                                  [
+                                    {
+                                      "name": "position",
+                                      "type": "BlockCoordinates"
+                                    },
+                                    {
+                                      "name": "face",
+                                      "type": "zigzag32"
+                                    }
+                                  ]
+                                ],
+                                "continue_break": [
+                                  "container",
+                                  [
+                                    {
+                                      "name": "position",
+                                      "type": "BlockCoordinates"
+                                    },
+                                    {
+                                      "name": "face",
+                                      "type": "zigzag32"
+                                    }
+                                  ]
+                                ]
+                              },
+                              "default": "void"
+                            }
+                          ]
+                        }
+                      ]
+                    ]
+                  }
+                ]
+              },
+              "default": "void"
+            }
+          ]
         }
       ]
     ],
@@ -6896,7 +7057,13 @@
       [
         {
           "name": "requests",
-          "type": "ItemStackRequests"
+          "type": [
+            "array",
+            {
+              "countType": "varint",
+              "type": "ItemStackRequest"
+            }
+          ]
         }
       ]
     ],
@@ -7304,72 +7471,72 @@
         "type": "zigzag64",
         "big": true,
         "shift": true,
-        "flags": {
-          "onfire": 0,
-          "sneaking": 1,
-          "riding": 2,
-          "sprinting": 3,
-          "action": 4,
-          "invisible": 5,
-          "tempted": 6,
-          "inlove": 7,
-          "saddled": 8,
-          "powered": 9,
-          "ignited": 10,
-          "baby": 11,
-          "converting": 12,
-          "critical": 13,
-          "can_show_nametag": 14,
-          "always_show_nametag": 15,
-          "no_ai": 16,
-          "silent": 17,
-          "wallclimbing": 18,
-          "can_climb": 19,
-          "swimmer": 20,
-          "can_fly": 21,
-          "walker": 22,
-          "resting": 23,
-          "sitting": 24,
-          "angry": 25,
-          "interested": 26,
-          "charged": 27,
-          "tamed": 28,
-          "orphaned": 29,
-          "leashed": 30,
-          "sheared": 31,
-          "gliding": 32,
-          "elder": 33,
-          "moving": 34,
-          "breathing": 35,
-          "chested": 36,
-          "stackable": 37,
-          "showbase": 38,
-          "rearing": 39,
-          "vibrating": 40,
-          "idling": 41,
-          "evoker_spell": 42,
-          "charge_attack": 43,
-          "wasd_controlled": 44,
-          "can_power_jump": 45,
-          "linger": 46,
-          "has_collision": 47,
-          "affected_by_gravity": 48,
-          "fire_immune": 49,
-          "dancing": 50,
-          "enchanted": 51,
-          "show_trident_rope": 52,
-          "container_private": 53,
-          "transforming": 54,
-          "spin_attack": 55,
-          "swimming": 56,
-          "bribed": 57,
-          "pregnant": 58,
-          "laying_egg": 59,
-          "rider_can_pick": 60,
-          "transition_sitting": 61,
-          "eating": 62,
-          "laying_down": 63
-        }
+        "flags": [
+          "onfire",
+          "sneaking",
+          "riding",
+          "sprinting",
+          "action",
+          "invisible",
+          "tempted",
+          "inlove",
+          "saddled",
+          "powered",
+          "ignited",
+          "baby",
+          "converting",
+          "critical",
+          "can_show_nametag",
+          "always_show_nametag",
+          "no_ai",
+          "silent",
+          "wallclimbing",
+          "can_climb",
+          "swimmer",
+          "can_fly",
+          "walker",
+          "resting",
+          "sitting",
+          "angry",
+          "interested",
+          "charged",
+          "tamed",
+          "orphaned",
+          "leashed",
+          "sheared",
+          "gliding",
+          "elder",
+          "moving",
+          "breathing",
+          "chested",
+          "stackable",
+          "showbase",
+          "rearing",
+          "vibrating",
+          "idling",
+          "evoker_spell",
+          "charge_attack",
+          "wasd_controlled",
+          "can_power_jump",
+          "linger",
+          "has_collision",
+          "affected_by_gravity",
+          "fire_immune",
+          "dancing",
+          "enchanted",
+          "show_trident_rope",
+          "container_private",
+          "transforming",
+          "spin_attack",
+          "swimming",
+          "bribed",
+          "pregnant",
+          "laying_egg",
+          "rider_can_pick",
+          "transition_sitting",
+          "eating",
+          "laying_down"
+        ]
       }
     ],
     "MetadataFlags2": [
@@ -7377,40 +7544,39 @@
       {
         "type": "zigzag64",
         "big": true,
-        "shift": true,
-        "flags": {
-          "sneezing": 64,
-          "trusting": 65,
-          "rolling": 66,
-          "scared": 67,
-          "in_scaffolding": 68,
-          "over_scaffolding": 69,
-          "fall_through_scaffolding": 70,
-          "blocking": 71,
-          "transition_blocking": 72,
-          "blocked_using_shield": 73,
-          "blocked_using_damaged_shield": 74,
-          "sleeping": 75,
-          "wants_to_wake": 76,
-          "trade_interest": 77,
-          "door_breaker": 78,
-          "breaking_obstruction": 79,
-          "door_opener": 80,
-          "illager_captain": 81,
-          "stunned": 82,
-          "roaring": 83,
-          "delayed_attacking": 84,
-          "avoiding_mobs": 85,
-          "avoiding_block": 86,
-          "facing_target_to_range_attack": 87,
-          "hidden_when_invisible": 88,
-          "is_in_ui": 89,
-          "stalking": 90,
-          "emoting": 91,
-          "celebrating": 92,
-          "admiring": 93,
-          "celebrating_special": 94
-        }
+        "flags": [
+          "sneezing",
+          "trusting",
+          "rolling",
+          "scared",
+          "in_scaffolding",
+          "over_scaffolding",
+          "fall_through_scaffolding",
+          "blocking",
+          "transition_blocking",
+          "blocked_using_shield",
+          "blocked_using_damaged_shield",
+          "sleeping",
+          "wants_to_wake",
+          "trade_interest",
+          "door_breaker",
+          "breaking_obstruction",
+          "door_opener",
+          "illager_captain",
+          "stunned",
+          "roaring",
+          "delayed_attacking",
+          "avoiding_mobs",
+          "avoiding_block",
+          "facing_target_to_range_attack",
+          "hidden_when_invisible",
+          "is_in_ui",
+          "stalking",
+          "emoting",
+          "celebrating",
+          "admiring",
+          "celebrating_special"
+        ]
       }
     ],
     "UpdateBlockFlags": [
@@ -7499,46 +7665,47 @@
     "InputFlag": [
       "bitflags",
       {
-        "type": "varint",
-        "flags": {
-          "ascend": 1,
-          "descend": 2,
-          "north_jump": 4,
-          "jump_down": 8,
-          "sprint_down": 16,
-          "change_height": 32,
-          "jumping": 64,
-          "auto_jumping_in_water": 128,
-          "sneaking": 256,
-          "sneak_down": 512,
-          "up": 1024,
-          "down": 2048,
-          "left": 4096,
-          "right": 8192,
-          "up_left": 16384,
-          "up_right": 32768,
-          "want_up": 65536,
-          "want_down": 131072,
-          "want_down_slow": 262144,
-          "want_up_slow": 524288,
-          "sprinting": 1048576,
-          "ascend_scaffolding": 2097152,
-          "descend_scaffolding": 4194304,
-          "sneak_toggle_down": 8388608,
-          "persist_sneak": 16777216,
-          "start_sprinting": 33554432,
-          "stop_sprinting": 67108864,
-          "start_sneaking": 134217728,
-          "stop_sneaking": 134217728,
-          "start_swimming": 268435456,
-          "stop_swimming": 536870912,
-          "start_jumping": 1073741824,
-          "start_gliding": 2147483648,
-          "stop_gliding": 4294967296,
-          "item_interact": 8589934592,
-          "block_action": 17179869184,
-          "item_stack_request": 34359738368
-        }
+        "type": "varint64",
+        "big": true,
+        "flags": [
+          "ascend",
+          "descend",
+          "north_jump",
+          "jump_down",
+          "sprint_down",
+          "change_height",
+          "jumping",
+          "auto_jumping_in_water",
+          "sneaking",
+          "sneak_down",
+          "up",
+          "down",
+          "left",
+          "right",
+          "up_left",
+          "up_right",
+          "want_up",
+          "want_down",
+          "want_down_slow",
+          "want_up_slow",
+          "sprinting",
+          "ascend_scaffolding",
+          "descend_scaffolding",
+          "sneak_toggle_down",
+          "persist_sneak",
+          "start_sprinting",
+          "stop_sprinting",
+          "start_sneaking",
+          "stop_sneaking",
+          "start_swimming",
+          "stop_swimming",
+          "start_jumping",
+          "start_gliding",
+          "stop_gliding",
+          "item_interact",
+          "block_action",
+          "item_stack_request"
+        ]
       }
     ],
     "ArmorDamageType": [

--- a/data/1.16.210/protocol.json
+++ b/data/1.16.210/protocol.json
@@ -1,0 +1,7553 @@
+{
+  "types": {
+    "varint32": "varint",
+    "bool": "native",
+    "zigzag32": "native",
+    "zigzag64": "native",
+    "uuid": "native",
+    "byterot": "native",
+    "MapInfo": "native",
+    "nbt": "native",
+    "BehaviourPackInfos": [
+      "array",
+      {
+        "countType": "li16",
+        "type": [
+          "container",
+          [
+            {
+              "name": "uuid",
+              "type": "string"
+            },
+            {
+              "name": "version",
+              "type": "string"
+            },
+            {
+              "name": "size",
+              "type": "lu64"
+            },
+            {
+              "name": "content_key",
+              "type": "string"
+            },
+            {
+              "name": "sub_pack_name",
+              "type": "string"
+            },
+            {
+              "name": "content_identity",
+              "type": "string"
+            },
+            {
+              "name": "has_scripts",
+              "type": "bool"
+            }
+          ]
+        ]
+      }
+    ],
+    "TexturePackInfos": [
+      "array",
+      {
+        "countType": "li16",
+        "type": [
+          "container",
+          [
+            {
+              "name": "uuid",
+              "type": "string"
+            },
+            {
+              "name": "version",
+              "type": "string"
+            },
+            {
+              "name": "size",
+              "type": "lu64"
+            },
+            {
+              "name": "content_key",
+              "type": "string"
+            },
+            {
+              "name": "sub_pack_name",
+              "type": "string"
+            },
+            {
+              "name": "content_identity",
+              "type": "string"
+            },
+            {
+              "name": "has_scripts",
+              "type": "bool"
+            },
+            {
+              "name": "rtx_enabled",
+              "type": "bool"
+            }
+          ]
+        ]
+      }
+    ],
+    "ResourcePackIdVersions": [
+      "array",
+      {
+        "countType": "varint",
+        "type": [
+          "container",
+          [
+            {
+              "name": "uuid",
+              "type": "string"
+            },
+            {
+              "name": "version",
+              "type": "string"
+            },
+            {
+              "name": "name",
+              "type": "string"
+            }
+          ]
+        ]
+      }
+    ],
+    "ResourcePackIds": [
+      "array",
+      {
+        "countType": "li16",
+        "type": "string"
+      }
+    ],
+    "Experiment": [
+      "container",
+      [
+        {
+          "name": "name",
+          "type": "string"
+        },
+        {
+          "name": "enabled",
+          "type": "bool"
+        }
+      ]
+    ],
+    "Experiments": [
+      "array",
+      {
+        "countType": "li32",
+        "type": "Experiment"
+      }
+    ],
+    "GameMode": [
+      "mapper",
+      {
+        "type": "zigzag32",
+        "mappings": {
+          "0": "survival",
+          "1": "creative",
+          "2": "adventure",
+          "3": "survival_spectator",
+          "4": "creative_spectator",
+          "5": "fallback"
+        }
+      }
+    ],
+    "GameRule": [
+      "container",
+      [
+        {
+          "name": "name",
+          "type": "string"
+        },
+        {
+          "name": "type",
+          "type": [
+            "mapper",
+            {
+              "type": "varint",
+              "mappings": {
+                "1": "bool",
+                "2": "int",
+                "3": "float"
+              }
+            }
+          ]
+        },
+        {
+          "name": "value",
+          "type": [
+            "switch",
+            {
+              "compareTo": "type",
+              "fields": {
+                "bool": "bool",
+                "int": "zigzag32",
+                "float": "lf32"
+              },
+              "default": "void"
+            }
+          ]
+        }
+      ]
+    ],
+    "GameRules": [
+      "array",
+      {
+        "countType": "varint",
+        "type": "GameRule"
+      }
+    ],
+    "Blob": [
+      "container",
+      [
+        {
+          "name": "hash",
+          "type": "lu64"
+        },
+        {
+          "name": "payload",
+          "type": "ByteArray"
+        }
+      ]
+    ],
+    "BlockPalette": [
+      "array",
+      {
+        "countType": "varint",
+        "type": [
+          "container",
+          [
+            {
+              "name": "name",
+              "type": "string"
+            },
+            {
+              "name": "state",
+              "type": "nbt"
+            }
+          ]
+        ]
+      }
+    ],
+    "Itemstates": [
+      "array",
+      {
+        "countType": "varint",
+        "type": [
+          "container",
+          [
+            {
+              "name": "name",
+              "type": "string"
+            },
+            {
+              "name": "runtime_id",
+              "type": "li16"
+            },
+            {
+              "name": "component_based",
+              "type": "bool"
+            }
+          ]
+        ]
+      }
+    ],
+    "Item": [
+      "container",
+      [
+        {
+          "name": "network_id",
+          "type": "zigzag32"
+        },
+        {
+          "anon": true,
+          "type": [
+            "switch",
+            {
+              "compareTo": "network_id",
+              "fields": {
+                "0": "void"
+              },
+              "default": [
+                "container",
+                [
+                  {
+                    "name": "auxiliary_value",
+                    "type": "zigzag32"
+                  },
+                  {
+                    "name": "has_nbt",
+                    "type": [
+                      "mapper",
+                      {
+                        "type": "lu16",
+                        "mappings": {
+                          "0": "false",
+                          "65535": "true"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "name": "nbt",
+                    "type": [
+                      "switch",
+                      {
+                        "compareTo": "has_nbt",
+                        "fields": {
+                          "true": [
+                            "container",
+                            [
+                              {
+                                "name": "version",
+                                "type": "u8"
+                              },
+                              {
+                                "name": "nbt",
+                                "type": "nbt"
+                              }
+                            ]
+                          ]
+                        },
+                        "default": "void"
+                      }
+                    ]
+                  },
+                  {
+                    "name": "can_place_on",
+                    "type": [
+                      "array",
+                      {
+                        "countType": "zigzag32",
+                        "type": "string"
+                      }
+                    ]
+                  },
+                  {
+                    "name": "can_destroy",
+                    "type": [
+                      "array",
+                      {
+                        "countType": "zigzag32",
+                        "type": "string"
+                      }
+                    ]
+                  }
+                ]
+              ]
+            }
+          ]
+        },
+        {
+          "anon": true,
+          "type": [
+            "switch",
+            {
+              "compareTo": "network_id",
+              "fields": {
+                "355": [
+                  "container",
+                  [
+                    {
+                      "name": "blocking_tick",
+                      "type": "zigzag64"
+                    }
+                  ]
+                ]
+              },
+              "default": "void"
+            }
+          ]
+        }
+      ]
+    ],
+    "vec3i": [
+      "container",
+      [
+        {
+          "name": "x",
+          "type": "zigzag32"
+        },
+        {
+          "name": "y",
+          "type": "zigzag32"
+        },
+        {
+          "name": "z",
+          "type": "zigzag32"
+        }
+      ]
+    ],
+    "vec3u": [
+      "container",
+      [
+        {
+          "name": "x",
+          "type": "varint"
+        },
+        {
+          "name": "y",
+          "type": "varint"
+        },
+        {
+          "name": "z",
+          "type": "varint"
+        }
+      ]
+    ],
+    "vec3f": [
+      "container",
+      [
+        {
+          "name": "x",
+          "type": "lf32"
+        },
+        {
+          "name": "y",
+          "type": "lf32"
+        },
+        {
+          "name": "z",
+          "type": "lf32"
+        }
+      ]
+    ],
+    "vec2f": [
+      "container",
+      [
+        {
+          "name": "x",
+          "type": "lf32"
+        },
+        {
+          "name": "z",
+          "type": "lf32"
+        }
+      ]
+    ],
+    "MetadataDictionary": [
+      "array",
+      {
+        "countType": "varint",
+        "type": [
+          "container",
+          [
+            {
+              "name": "key",
+              "type": [
+                "mapper",
+                {
+                  "type": "varint",
+                  "mappings": {
+                    "0": "flags",
+                    "1": "health",
+                    "2": "variant",
+                    "3": "color",
+                    "4": "nametag",
+                    "5": "owner_eid",
+                    "6": "target_eid",
+                    "7": "air",
+                    "8": "potion_color",
+                    "9": "potion_ambient",
+                    "10": "jump_duration",
+                    "11": "hurt_time",
+                    "12": "hurt_direction",
+                    "13": "paddle_time_left",
+                    "14": "paddle_time_right",
+                    "15": "experience_value",
+                    "16": "minecart_display_block",
+                    "17": "minecart_display_offset",
+                    "18": "minecart_has_display",
+                    "20": "old_swell",
+                    "21": "swell_dir",
+                    "22": "charge_amount",
+                    "23": "enderman_held_runtime_id",
+                    "24": "entity_age",
+                    "26": "player_flags",
+                    "27": "player_index",
+                    "28": "player_bed_position",
+                    "29": "fireball_power_x",
+                    "30": "fireball_power_y",
+                    "31": "fireball_power_z",
+                    "32": "aux_power",
+                    "33": "fish_x",
+                    "34": "fish_z",
+                    "35": "fish_angle",
+                    "36": "potion_aux_value",
+                    "37": "lead_holder_eid",
+                    "38": "scale",
+                    "39": "interactive_tag",
+                    "40": "npc_skin_id",
+                    "41": "url_tag",
+                    "42": "max_airdata_max_air",
+                    "43": "mark_variant",
+                    "44": "container_type",
+                    "45": "container_base_size",
+                    "46": "container_extra_slots_per_strength",
+                    "47": "block_target",
+                    "48": "wither_invulnerable_ticks",
+                    "49": "wither_target_1",
+                    "50": "wither_target_2",
+                    "51": "wither_target_3",
+                    "52": "aerial_attack",
+                    "53": "boundingbox_width",
+                    "54": "boundingbox_height",
+                    "55": "fuse_length",
+                    "56": "rider_seat_position",
+                    "57": "rider_rotation_locked",
+                    "58": "rider_max_rotation",
+                    "59": "rider_min_rotation",
+                    "60": "rider_rotation_offset",
+                    "61": "area_effect_cloud_radius",
+                    "62": "area_effect_cloud_waiting",
+                    "63": "area_effect_cloud_particle_id",
+                    "64": "shulker_peek_id",
+                    "65": "shulker_attach_face",
+                    "66": "shulker_attached",
+                    "67": "shulker_attach_pos",
+                    "68": "trading_player_eid",
+                    "69": "trading_career",
+                    "70": "has_command_block",
+                    "71": "command_block_command",
+                    "72": "command_block_last_output",
+                    "73": "command_block_track_output",
+                    "74": "controlling_rider_seat_number",
+                    "75": "strength",
+                    "76": "max_strength",
+                    "77": "spell_casting_color",
+                    "78": "limited_life",
+                    "79": "armor_stand_pose_index",
+                    "80": "ender_crystal_time_offset",
+                    "81": "always_show_nametag",
+                    "82": "color_2",
+                    "83": "name_author",
+                    "84": "score_tag",
+                    "85": "balloon_attached_entity",
+                    "86": "pufferfish_size",
+                    "87": "bubble_time",
+                    "88": "agent",
+                    "89": "sitting_amount",
+                    "90": "sitting_amount_previous",
+                    "91": "eating_counter",
+                    "92": "flags_extended",
+                    "93": "laying_amount",
+                    "94": "laying_amount_previous",
+                    "95": "duration",
+                    "96": "spawn_time",
+                    "97": "change_rate",
+                    "98": "change_on_pickup",
+                    "99": "pickup_count",
+                    "100": "interact_text",
+                    "101": "trade_tier",
+                    "102": "max_trade_tier",
+                    "103": "trade_experience",
+                    "104": "skin_id",
+                    "105": "spawning_frames",
+                    "106": "command_block_tick_delay",
+                    "107": "command_block_execute_on_first_tick",
+                    "108": "ambient_sound_interval",
+                    "109": "ambient_sound_interval_range",
+                    "110": "ambient_sound_event_name",
+                    "111": "fall_damage_multiplier",
+                    "112": "name_raw_text",
+                    "113": "can_ride_target",
+                    "114": "low_tier_cured_discount",
+                    "115": "high_tier_cured_discount",
+                    "116": "nearby_cured_discount",
+                    "117": "nearby_cured_discount_timestamp",
+                    "118": "hitbox",
+                    "119": "is_buoyant",
+                    "120": "buoyancy_data",
+                    "121": "goat_horn_count"
+                  }
+                }
+              ]
+            },
+            {
+              "name": "type",
+              "type": [
+                "mapper",
+                {
+                  "type": "varint",
+                  "mappings": {
+                    "0": "byte",
+                    "1": "short",
+                    "2": "int",
+                    "3": "float",
+                    "4": "string",
+                    "5": "compound",
+                    "6": "vec3i",
+                    "7": "long",
+                    "8": "vec3f"
+                  }
+                }
+              ]
+            },
+            {
+              "name": "value",
+              "type": [
+                "switch",
+                {
+                  "compareTo": "key",
+                  "fields": {
+                    "flags": "MetadataFlags1",
+                    "flags_extended": "MetadataFlags2"
+                  },
+                  "default": [
+                    "switch",
+                    {
+                      "compareTo": "type",
+                      "fields": {
+                        "byte": "i8",
+                        "short": "li16",
+                        "int": "zigzag32",
+                        "float": "lf32",
+                        "string": "string",
+                        "compound": "nbt",
+                        "vec3i": "vec3i",
+                        "long": "zigzag64",
+                        "vec3f": "vec3f"
+                      },
+                      "default": "void"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        ]
+      }
+    ],
+    "Link": [
+      "container",
+      [
+        {
+          "name": "ridden_entity_id",
+          "type": "zigzag64"
+        },
+        {
+          "name": "rider_entity_id",
+          "type": "zigzag64"
+        },
+        {
+          "name": "type",
+          "type": "u8"
+        },
+        {
+          "name": "immediate",
+          "type": "bool"
+        },
+        {
+          "name": "rider_initiated",
+          "type": "bool"
+        }
+      ]
+    ],
+    "Links": [
+      "array",
+      {
+        "countType": "varint",
+        "type": "Link"
+      }
+    ],
+    "EntityAttributes": [
+      "array",
+      {
+        "countType": "varint",
+        "type": [
+          "container",
+          [
+            {
+              "name": "name",
+              "type": "string"
+            },
+            {
+              "name": "min",
+              "type": "lf32"
+            },
+            {
+              "name": "value",
+              "type": "lf32"
+            },
+            {
+              "name": "max",
+              "type": "lf32"
+            }
+          ]
+        ]
+      }
+    ],
+    "Rotation": [
+      "container",
+      [
+        {
+          "name": "yaw",
+          "type": "byterot"
+        },
+        {
+          "name": "pitch",
+          "type": "byterot"
+        },
+        {
+          "name": "head_yaw",
+          "type": "byterot"
+        }
+      ]
+    ],
+    "BlockCoordinates": [
+      "container",
+      [
+        {
+          "name": "x",
+          "type": "zigzag32"
+        },
+        {
+          "name": "y",
+          "type": "varint"
+        },
+        {
+          "name": "z",
+          "type": "zigzag32"
+        }
+      ]
+    ],
+    "PlayerAttributes": [
+      "array",
+      {
+        "countType": "varint",
+        "type": [
+          "container",
+          [
+            {
+              "name": "min",
+              "type": "lf32"
+            },
+            {
+              "name": "max",
+              "type": "lf32"
+            },
+            {
+              "name": "current",
+              "type": "lf32"
+            },
+            {
+              "name": "default",
+              "type": "lf32"
+            },
+            {
+              "name": "name",
+              "type": "string"
+            }
+          ]
+        ]
+      }
+    ],
+    "Transaction": [
+      "container",
+      [
+        {
+          "name": "legacy_request_id",
+          "type": "zigzag32"
+        },
+        {
+          "name": "legacy_transactions",
+          "type": [
+            "switch",
+            {
+              "compareTo": "legacy_request_id",
+              "fields": {
+                "0": "void"
+              },
+              "default": [
+                "array",
+                {
+                  "countType": "varint",
+                  "type": [
+                    "container",
+                    [
+                      {
+                        "name": "container_id",
+                        "type": "u8"
+                      },
+                      {
+                        "name": "changed_slots",
+                        "type": [
+                          "array",
+                          {
+                            "countType": "varint",
+                            "type": [
+                              "container",
+                              [
+                                {
+                                  "name": "slot_id",
+                                  "type": "u8"
+                                }
+                              ]
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "transaction_type",
+          "type": [
+            "mapper",
+            {
+              "type": "varint",
+              "mappings": {
+                "0": "normal",
+                "1": "inventory_mismatch",
+                "2": "item_use",
+                "3": "item_use_on_entity",
+                "4": "item_release"
+              }
+            }
+          ]
+        },
+        {
+          "name": "network_ids",
+          "type": "bool"
+        },
+        {
+          "name": "inventory_actions",
+          "type": [
+            "array",
+            {
+              "countType": "varint",
+              "type": [
+                "container",
+                [
+                  {
+                    "name": "source_type",
+                    "type": [
+                      "mapper",
+                      {
+                        "type": "varint",
+                        "mappings": {
+                          "0": "container",
+                          "1": "global",
+                          "2": "world_interaction",
+                          "3": "creative",
+                          "100": "craft_slot",
+                          "99999": "craft"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "anon": true,
+                    "type": [
+                      "switch",
+                      {
+                        "compareTo": "source_type",
+                        "fields": {
+                          "container": [
+                            "container",
+                            [
+                              {
+                                "name": "inventory_id",
+                                "type": "varint"
+                              }
+                            ]
+                          ],
+                          "creative": [
+                            "container",
+                            [
+                              {
+                                "name": "inventory_id",
+                                "type": "varint"
+                              }
+                            ]
+                          ],
+                          "world_interaction": [
+                            "container",
+                            [
+                              {
+                                "name": "flags",
+                                "type": "varint"
+                              }
+                            ]
+                          ],
+                          "craft": [
+                            "container",
+                            [
+                              {
+                                "name": "action",
+                                "type": "varint"
+                              }
+                            ]
+                          ],
+                          "craft_slot": [
+                            "container",
+                            [
+                              {
+                                "name": "action",
+                                "type": "varint"
+                              }
+                            ]
+                          ]
+                        },
+                        "default": "void"
+                      }
+                    ]
+                  },
+                  {
+                    "name": "slot",
+                    "type": "varint"
+                  },
+                  {
+                    "name": "old_item",
+                    "type": "Item"
+                  },
+                  {
+                    "name": "new_item",
+                    "type": "Item"
+                  },
+                  {
+                    "name": "new_item_stack_id",
+                    "type": [
+                      "switch",
+                      {
+                        "compareTo": "../network_ids",
+                        "fields": {
+                          "true": "zigzag32"
+                        },
+                        "default": "void"
+                      }
+                    ]
+                  }
+                ]
+              ]
+            }
+          ]
+        },
+        {
+          "name": "transaction_data",
+          "type": [
+            "switch",
+            {
+              "compareTo": "transaction_type",
+              "fields": {
+                "normal": "void",
+                "inventory_mismatch": "void",
+                "item_use": [
+                  "container",
+                  [
+                    {
+                      "name": "action_type",
+                      "type": [
+                        "mapper",
+                        {
+                          "type": "varint",
+                          "mappings": {
+                            "0": "click_block",
+                            "1": "click_air",
+                            "2": "break_block"
+                          }
+                        }
+                      ]
+                    },
+                    {
+                      "name": "block_position",
+                      "type": "BlockCoordinates"
+                    },
+                    {
+                      "name": "face",
+                      "type": "varint"
+                    },
+                    {
+                      "name": "hotbar_slot",
+                      "type": "varint"
+                    },
+                    {
+                      "name": "held_item",
+                      "type": "Item"
+                    },
+                    {
+                      "name": "player_pos",
+                      "type": "vec3f"
+                    },
+                    {
+                      "name": "click_pos",
+                      "type": "vec3f"
+                    },
+                    {
+                      "name": "block_runtime_id",
+                      "type": "varint"
+                    }
+                  ]
+                ],
+                "item_use_on_entity": [
+                  "container",
+                  [
+                    {
+                      "name": "entity_runtime_id",
+                      "type": "varint64"
+                    },
+                    {
+                      "name": "action_type",
+                      "type": [
+                        "mapper",
+                        {
+                          "type": "varint",
+                          "mappings": {
+                            "0": "interact",
+                            "1": "attack"
+                          }
+                        }
+                      ]
+                    },
+                    {
+                      "name": "hotbar_slot",
+                      "type": "zigzag32"
+                    },
+                    {
+                      "name": "held_item",
+                      "type": "Item"
+                    },
+                    {
+                      "name": "player_pos",
+                      "type": "vec3f"
+                    },
+                    {
+                      "name": "click_pos",
+                      "type": "vec3f"
+                    }
+                  ]
+                ],
+                "item_release": [
+                  "container",
+                  [
+                    {
+                      "name": "action_type",
+                      "type": [
+                        "mapper",
+                        {
+                          "type": "varint",
+                          "mappings": {
+                            "0": "release",
+                            "1": "consume"
+                          }
+                        }
+                      ]
+                    },
+                    {
+                      "name": "hotbar_slot",
+                      "type": "zigzag32"
+                    },
+                    {
+                      "name": "held_item",
+                      "type": "Item"
+                    },
+                    {
+                      "name": "head_pos",
+                      "type": "vec3f"
+                    }
+                  ]
+                ]
+              },
+              "default": "void"
+            }
+          ]
+        }
+      ]
+    ],
+    "ItemStack": [
+      "container",
+      [
+        {
+          "name": "runtime_id",
+          "type": "zigzag32"
+        },
+        {
+          "name": "item",
+          "type": "Item"
+        }
+      ]
+    ],
+    "ItemStacks": [
+      "array",
+      {
+        "countType": "varint",
+        "type": "ItemStack"
+      }
+    ],
+    "RecipeIngredient": [
+      "container",
+      [
+        {
+          "name": "network_id",
+          "type": "zigzag32"
+        },
+        {
+          "anon": true,
+          "type": [
+            "switch",
+            {
+              "compareTo": "network_id",
+              "fields": {
+                "0": "void"
+              },
+              "default": [
+                "container",
+                [
+                  {
+                    "name": "network_data",
+                    "type": "zigzag32"
+                  },
+                  {
+                    "name": "count",
+                    "type": "zigzag32"
+                  }
+                ]
+              ]
+            }
+          ]
+        }
+      ]
+    ],
+    "PotionTypeRecipes": [
+      "array",
+      {
+        "countType": "varint",
+        "type": [
+          "container",
+          [
+            {
+              "name": "input_item_id",
+              "type": "zigzag32"
+            },
+            {
+              "name": "input_item_meta",
+              "type": "zigzag32"
+            },
+            {
+              "name": "ingredient_id",
+              "type": "zigzag32"
+            },
+            {
+              "name": "ingredient_meta",
+              "type": "zigzag32"
+            },
+            {
+              "name": "output_item_id",
+              "type": "zigzag32"
+            },
+            {
+              "name": "output_item_meta",
+              "type": "zigzag32"
+            }
+          ]
+        ]
+      }
+    ],
+    "PotionContainerChangeRecipes": [
+      "array",
+      {
+        "countType": "varint",
+        "type": [
+          "container",
+          [
+            {
+              "name": "input_item_id",
+              "type": "zigzag32"
+            },
+            {
+              "name": "ingredient_id",
+              "type": "zigzag32"
+            },
+            {
+              "name": "output_item_id",
+              "type": "zigzag32"
+            }
+          ]
+        ]
+      }
+    ],
+    "Recipes": [
+      "array",
+      {
+        "countType": "varint",
+        "type": [
+          "container",
+          [
+            {
+              "name": "type",
+              "type": [
+                "mapper",
+                {
+                  "type": "zigzag32",
+                  "mappings": {
+                    "0": "shapeless",
+                    "1": "shaped",
+                    "2": "furnace",
+                    "3": "furnace_with_metadata",
+                    "4": "multi",
+                    "5": "shulker_box",
+                    "6": "shapeless_chemistry",
+                    "7": "shaped_chemistry"
+                  }
+                }
+              ]
+            },
+            {
+              "name": "recipe",
+              "type": [
+                "switch",
+                {
+                  "compareTo": "type",
+                  "fields": {
+                    "shapeless": [
+                      "container",
+                      [
+                        {
+                          "name": "recipe_id",
+                          "type": "string"
+                        },
+                        {
+                          "name": "input",
+                          "type": [
+                            "array",
+                            {
+                              "countType": "varint",
+                              "type": "RecipeIngredient"
+                            }
+                          ]
+                        },
+                        {
+                          "name": "output",
+                          "type": [
+                            "array",
+                            {
+                              "countType": "varint",
+                              "type": "Item"
+                            }
+                          ]
+                        },
+                        {
+                          "name": "uuid",
+                          "type": "uuid"
+                        },
+                        {
+                          "name": "block",
+                          "type": "string"
+                        },
+                        {
+                          "name": "priority",
+                          "type": "zigzag32"
+                        },
+                        {
+                          "name": "network_id",
+                          "type": "zigzag32"
+                        }
+                      ]
+                    ],
+                    "shulker_box": [
+                      "container",
+                      [
+                        {
+                          "name": "recipe_id",
+                          "type": "string"
+                        },
+                        {
+                          "name": "input",
+                          "type": [
+                            "array",
+                            {
+                              "countType": "varint",
+                              "type": "RecipeIngredient"
+                            }
+                          ]
+                        },
+                        {
+                          "name": "output",
+                          "type": [
+                            "array",
+                            {
+                              "countType": "varint",
+                              "type": "Item"
+                            }
+                          ]
+                        },
+                        {
+                          "name": "uuid",
+                          "type": "uuid"
+                        },
+                        {
+                          "name": "block",
+                          "type": "string"
+                        },
+                        {
+                          "name": "priority",
+                          "type": "zigzag32"
+                        },
+                        {
+                          "name": "network_id",
+                          "type": "zigzag32"
+                        }
+                      ]
+                    ],
+                    "shapeless_chemistry": [
+                      "container",
+                      [
+                        {
+                          "name": "recipe_id",
+                          "type": "string"
+                        },
+                        {
+                          "name": "input",
+                          "type": [
+                            "array",
+                            {
+                              "countType": "varint",
+                              "type": "RecipeIngredient"
+                            }
+                          ]
+                        },
+                        {
+                          "name": "output",
+                          "type": [
+                            "array",
+                            {
+                              "countType": "varint",
+                              "type": "Item"
+                            }
+                          ]
+                        },
+                        {
+                          "name": "uuid",
+                          "type": "uuid"
+                        },
+                        {
+                          "name": "block",
+                          "type": "string"
+                        },
+                        {
+                          "name": "priority",
+                          "type": "zigzag32"
+                        },
+                        {
+                          "name": "network_id",
+                          "type": "zigzag32"
+                        }
+                      ]
+                    ],
+                    "shaped": [
+                      "container",
+                      [
+                        {
+                          "name": "recipe_id",
+                          "type": "string"
+                        },
+                        {
+                          "name": "width",
+                          "type": "zigzag32"
+                        },
+                        {
+                          "name": "height",
+                          "type": "zigzag32"
+                        },
+                        {
+                          "name": "input",
+                          "type": [
+                            "array",
+                            {
+                              "count": "width",
+                              "type": [
+                                "array",
+                                {
+                                  "count": "height",
+                                  "type": "RecipeIngredient"
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "name": "output",
+                          "type": [
+                            "array",
+                            {
+                              "countType": "varint",
+                              "type": "Item"
+                            }
+                          ]
+                        },
+                        {
+                          "name": "uuid",
+                          "type": "uuid"
+                        },
+                        {
+                          "name": "block",
+                          "type": "string"
+                        },
+                        {
+                          "name": "priority",
+                          "type": "zigzag32"
+                        },
+                        {
+                          "name": "network_id",
+                          "type": "zigzag32"
+                        }
+                      ]
+                    ],
+                    "shaped_chemistry": [
+                      "container",
+                      [
+                        {
+                          "name": "recipe_id",
+                          "type": "string"
+                        },
+                        {
+                          "name": "width",
+                          "type": "zigzag32"
+                        },
+                        {
+                          "name": "height",
+                          "type": "zigzag32"
+                        },
+                        {
+                          "name": "input",
+                          "type": [
+                            "array",
+                            {
+                              "count": "width",
+                              "type": [
+                                "array",
+                                {
+                                  "count": "height",
+                                  "type": "RecipeIngredient"
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "name": "output",
+                          "type": [
+                            "array",
+                            {
+                              "countType": "varint",
+                              "type": "Item"
+                            }
+                          ]
+                        },
+                        {
+                          "name": "uuid",
+                          "type": "uuid"
+                        },
+                        {
+                          "name": "block",
+                          "type": "string"
+                        },
+                        {
+                          "name": "priority",
+                          "type": "zigzag32"
+                        },
+                        {
+                          "name": "network_id",
+                          "type": "zigzag32"
+                        }
+                      ]
+                    ],
+                    "furnace": [
+                      "container",
+                      [
+                        {
+                          "name": "input_id",
+                          "type": "zigzag32"
+                        },
+                        {
+                          "name": "output",
+                          "type": "Item"
+                        },
+                        {
+                          "name": "block",
+                          "type": "string"
+                        }
+                      ]
+                    ],
+                    "furnace_with_metadata": [
+                      "container",
+                      [
+                        {
+                          "name": "input_id",
+                          "type": "zigzag32"
+                        },
+                        {
+                          "name": "input_meta",
+                          "type": "zigzag32"
+                        },
+                        {
+                          "name": "output",
+                          "type": "Item"
+                        },
+                        {
+                          "name": "block",
+                          "type": "string"
+                        }
+                      ]
+                    ],
+                    "multi": [
+                      "container",
+                      [
+                        {
+                          "name": "uuid",
+                          "type": "uuid"
+                        },
+                        {
+                          "name": "network_id",
+                          "type": "zigzag32"
+                        }
+                      ]
+                    ]
+                  },
+                  "default": "void"
+                }
+              ]
+            }
+          ]
+        ]
+      }
+    ],
+    "SkinImage": [
+      "container",
+      [
+        {
+          "name": "width",
+          "type": "li32"
+        },
+        {
+          "name": "height",
+          "type": "li32"
+        },
+        {
+          "name": "data",
+          "type": "string"
+        }
+      ]
+    ],
+    "Skin": [
+      "container",
+      [
+        {
+          "name": "skin_id",
+          "type": "string"
+        },
+        {
+          "name": "skin_resource_pack",
+          "type": "string"
+        },
+        {
+          "name": "skin_data",
+          "type": "SkinImage"
+        },
+        {
+          "name": "animations",
+          "type": [
+            "array",
+            {
+              "countType": "li32",
+              "type": [
+                "container",
+                [
+                  {
+                    "name": "skin_image",
+                    "type": "SkinImage"
+                  },
+                  {
+                    "name": "animation_type",
+                    "type": "li32"
+                  },
+                  {
+                    "name": "animation_frames",
+                    "type": "lf32"
+                  },
+                  {
+                    "name": "expression_type",
+                    "type": "lf32"
+                  }
+                ]
+              ]
+            }
+          ]
+        },
+        {
+          "name": "cape_data",
+          "type": "SkinImage"
+        },
+        {
+          "name": "geometry_data",
+          "type": "string"
+        },
+        {
+          "name": "animation_data",
+          "type": "string"
+        },
+        {
+          "name": "premium",
+          "type": "string"
+        },
+        {
+          "name": "persona",
+          "type": "bool"
+        },
+        {
+          "name": "cape_on_classic",
+          "type": "bool"
+        },
+        {
+          "name": "cape_id",
+          "type": "string"
+        },
+        {
+          "name": "full_skin_id",
+          "type": "string"
+        },
+        {
+          "name": "arm_size",
+          "type": "string"
+        },
+        {
+          "name": "skin_color",
+          "type": "string"
+        },
+        {
+          "name": "personal_pieces",
+          "type": [
+            "array",
+            {
+              "countType": "li32",
+              "type": [
+                "container",
+                [
+                  {
+                    "name": "piece_id",
+                    "type": "string"
+                  },
+                  {
+                    "name": "piece_type",
+                    "type": "string"
+                  },
+                  {
+                    "name": "pack_id",
+                    "type": "string"
+                  },
+                  {
+                    "name": "is_default_piece",
+                    "type": "bool"
+                  },
+                  {
+                    "name": "product_id",
+                    "type": "string"
+                  }
+                ]
+              ]
+            }
+          ]
+        },
+        {
+          "name": "piece_tint_colors",
+          "type": [
+            "array",
+            {
+              "countType": "li32",
+              "type": [
+                "container",
+                [
+                  {
+                    "name": "piece_type",
+                    "type": "string"
+                  },
+                  {
+                    "name": "colors",
+                    "type": [
+                      "array",
+                      {
+                        "countType": "li32",
+                        "type": "string"
+                      }
+                    ]
+                  }
+                ]
+              ]
+            }
+          ]
+        }
+      ]
+    ],
+    "PlayerRecords": [
+      "container",
+      [
+        {
+          "name": "type",
+          "type": [
+            "mapper",
+            {
+              "type": "u8",
+              "mappings": {
+                "0": "add",
+                "1": "remove"
+              }
+            }
+          ]
+        },
+        {
+          "name": "records_count",
+          "type": "varint"
+        },
+        {
+          "name": "records",
+          "type": [
+            "array",
+            {
+              "count": "records_count",
+              "type": [
+                "switch",
+                {
+                  "compareTo": "type",
+                  "fields": {
+                    "add": [
+                      "container",
+                      [
+                        {
+                          "name": "uuid",
+                          "type": "uuid"
+                        },
+                        {
+                          "name": "entity_unique_id",
+                          "type": "zigzag64"
+                        },
+                        {
+                          "name": "username",
+                          "type": "string"
+                        },
+                        {
+                          "name": "xbox_user_id",
+                          "type": "string"
+                        },
+                        {
+                          "name": "platform_chat_id",
+                          "type": "string"
+                        },
+                        {
+                          "name": "build_platform",
+                          "type": "li32"
+                        },
+                        {
+                          "name": "skin_data",
+                          "type": "Skin"
+                        },
+                        {
+                          "name": "is_teacher",
+                          "type": "bool"
+                        },
+                        {
+                          "name": "is_host",
+                          "type": "bool"
+                        }
+                      ]
+                    ],
+                    "remove": [
+                      "container",
+                      [
+                        {
+                          "name": "uuid",
+                          "type": "uuid"
+                        }
+                      ]
+                    ]
+                  },
+                  "default": "void"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "verified",
+          "type": [
+            "array",
+            {
+              "count": "records_count",
+              "type": "bool"
+            }
+          ]
+        }
+      ]
+    ],
+    "ScoreEntries": [
+      "container",
+      [
+        {
+          "name": "type",
+          "type": [
+            "mapper",
+            {
+              "type": "u8",
+              "mappings": {
+                "0": "change",
+                "1": "remove"
+              }
+            }
+          ]
+        },
+        {
+          "name": "entries",
+          "type": [
+            "array",
+            {
+              "countType": "varint",
+              "type": [
+                "container",
+                [
+                  {
+                    "name": "scoreboard_id",
+                    "type": "zigzag64"
+                  },
+                  {
+                    "name": "objective_name",
+                    "type": "string"
+                  },
+                  {
+                    "name": "score",
+                    "type": "li32"
+                  },
+                  {
+                    "anon": true,
+                    "type": [
+                      "switch",
+                      {
+                        "compareTo": "type",
+                        "fields": {
+                          "remove": [
+                            "container",
+                            [
+                              {
+                                "name": "entry_type",
+                                "type": [
+                                  "mapper",
+                                  {
+                                    "type": "i8",
+                                    "mappings": {
+                                      "1": "player",
+                                      "2": "entity",
+                                      "3": "fake_player"
+                                    }
+                                  }
+                                ]
+                              },
+                              {
+                                "name": "entity_unique_id",
+                                "type": [
+                                  "switch",
+                                  {
+                                    "compareTo": "entry_type",
+                                    "fields": {
+                                      "player": "zigzag64",
+                                      "entity": "zigzag64"
+                                    },
+                                    "default": "void"
+                                  }
+                                ]
+                              },
+                              {
+                                "name": "custom_name",
+                                "type": [
+                                  "switch",
+                                  {
+                                    "compareTo": "entry_type",
+                                    "fields": {
+                                      "fake_player": "string"
+                                    },
+                                    "default": "void"
+                                  }
+                                ]
+                              }
+                            ]
+                          ]
+                        },
+                        "default": "void"
+                      }
+                    ]
+                  }
+                ]
+              ]
+            }
+          ]
+        }
+      ]
+    ],
+    "ScoreboardIdentityEntries": [
+      "container",
+      [
+        {
+          "name": "type",
+          "type": [
+            "mapper",
+            {
+              "type": "i8",
+              "mappings": {
+                "0": "TYPE_REGISTER_IDENTITY",
+                "1": "TYPE_CLEAR_IDENTITY"
+              }
+            }
+          ]
+        },
+        {
+          "name": "entries",
+          "type": [
+            "array",
+            {
+              "countType": "varint",
+              "type": [
+                "container",
+                [
+                  {
+                    "name": "scoreboard_id",
+                    "type": "zigzag64"
+                  },
+                  {
+                    "name": "entity_unique_id",
+                    "type": [
+                      "switch",
+                      {
+                        "compareTo": "type",
+                        "fields": {
+                          "TYPE_REGISTER_IDENTITY": "zigzag64"
+                        },
+                        "default": "void"
+                      }
+                    ]
+                  }
+                ]
+              ]
+            }
+          ]
+        }
+      ]
+    ],
+    "Enchant": [
+      "container",
+      [
+        {
+          "name": "id",
+          "type": "u8"
+        },
+        {
+          "name": "level",
+          "type": "u8"
+        }
+      ]
+    ],
+    "EnchantOptions": [
+      "array",
+      {
+        "countType": "varint",
+        "type": [
+          "container",
+          [
+            {
+              "name": "cost",
+              "type": "varint"
+            },
+            {
+              "name": "slot_flags",
+              "type": "li32"
+            },
+            {
+              "name": "equip_enchants",
+              "type": [
+                "array",
+                {
+                  "countType": "varint",
+                  "type": "Enchant"
+                }
+              ]
+            },
+            {
+              "name": "held_enchants",
+              "type": [
+                "array",
+                {
+                  "countType": "varint",
+                  "type": "Enchant"
+                }
+              ]
+            },
+            {
+              "name": "self_enchants",
+              "type": [
+                "array",
+                {
+                  "countType": "varint",
+                  "type": "Enchant"
+                }
+              ]
+            },
+            {
+              "name": "name",
+              "type": "string"
+            },
+            {
+              "name": "option_id",
+              "type": "zigzag32"
+            }
+          ]
+        ]
+      }
+    ],
+    "StackRequestSlotInfo": [
+      "container",
+      [
+        {
+          "name": "container_id",
+          "type": "u8"
+        },
+        {
+          "name": "slot_id",
+          "type": "u8"
+        },
+        {
+          "name": "stack_id",
+          "type": "zigzag32"
+        }
+      ]
+    ],
+    "ItemStackRequests": [
+      "array",
+      {
+        "countType": "varint",
+        "type": [
+          "container",
+          [
+            {
+              "name": "request_id",
+              "type": "zigzag32"
+            },
+            {
+              "name": "actions",
+              "type": [
+                "array",
+                {
+                  "countType": "varint",
+                  "type": [
+                    "container",
+                    [
+                      {
+                        "name": "type_id",
+                        "type": [
+                          "mapper",
+                          {
+                            "type": "u8",
+                            "mappings": {
+                              "0": "take",
+                              "1": "place",
+                              "2": "swap",
+                              "3": "drop",
+                              "4": "destroy",
+                              "5": "consume",
+                              "6": "create",
+                              "7": "lab_table_combine",
+                              "8": "beacon_payment",
+                              "9": "mine_block",
+                              "10": "craft_recipe",
+                              "11": "craft_recipe_auto",
+                              "12": "craft_creative",
+                              "13": "optional",
+                              "14": "non_implemented",
+                              "15": "results_deprecated"
+                            }
+                          }
+                        ]
+                      },
+                      {
+                        "anon": true,
+                        "type": [
+                          "switch",
+                          {
+                            "compareTo": "type_id",
+                            "fields": {
+                              "take": [
+                                "container",
+                                [
+                                  {
+                                    "name": "count",
+                                    "type": "u8"
+                                  },
+                                  {
+                                    "name": "source",
+                                    "type": "StackRequestSlotInfo"
+                                  },
+                                  {
+                                    "name": "destination",
+                                    "type": "StackRequestSlotInfo"
+                                  }
+                                ]
+                              ],
+                              "place": [
+                                "container",
+                                [
+                                  {
+                                    "name": "count",
+                                    "type": "u8"
+                                  },
+                                  {
+                                    "name": "source",
+                                    "type": "StackRequestSlotInfo"
+                                  },
+                                  {
+                                    "name": "destination",
+                                    "type": "StackRequestSlotInfo"
+                                  }
+                                ]
+                              ],
+                              "swap": [
+                                "container",
+                                [
+                                  {
+                                    "name": "source",
+                                    "type": "StackRequestSlotInfo"
+                                  },
+                                  {
+                                    "name": "destination",
+                                    "type": "StackRequestSlotInfo"
+                                  }
+                                ]
+                              ],
+                              "drop": [
+                                "container",
+                                [
+                                  {
+                                    "name": "count",
+                                    "type": "u8"
+                                  },
+                                  {
+                                    "name": "source",
+                                    "type": "StackRequestSlotInfo"
+                                  },
+                                  {
+                                    "name": "randomly",
+                                    "type": "bool"
+                                  }
+                                ]
+                              ],
+                              "destroy": [
+                                "container",
+                                [
+                                  {
+                                    "name": "count",
+                                    "type": "u8"
+                                  },
+                                  {
+                                    "name": "source",
+                                    "type": "StackRequestSlotInfo"
+                                  }
+                                ]
+                              ],
+                              "consume": [
+                                "container",
+                                [
+                                  {
+                                    "name": "count",
+                                    "type": "u8"
+                                  },
+                                  {
+                                    "name": "source",
+                                    "type": "StackRequestSlotInfo"
+                                  }
+                                ]
+                              ],
+                              "create": [
+                                "container",
+                                [
+                                  {
+                                    "name": "result_slot_id",
+                                    "type": "u8"
+                                  }
+                                ]
+                              ],
+                              "beacon_payment": [
+                                "container",
+                                [
+                                  {
+                                    "name": "primary_effect",
+                                    "type": "zigzag32"
+                                  },
+                                  {
+                                    "name": "secondary_effect",
+                                    "type": "zigzag32"
+                                  }
+                                ]
+                              ],
+                              "mine_block": [
+                                "container",
+                                [
+                                  {
+                                    "name": "unknown1",
+                                    "type": "zigzag32"
+                                  },
+                                  {
+                                    "name": "predicted_durability",
+                                    "type": "zigzag32"
+                                  },
+                                  {
+                                    "name": "network_id",
+                                    "type": "zigzag32"
+                                  }
+                                ]
+                              ],
+                              "craft_recipe": [
+                                "container",
+                                [
+                                  {
+                                    "name": "recipe_network_id",
+                                    "type": "varint"
+                                  }
+                                ]
+                              ],
+                              "craft_recipe_auto": [
+                                "container",
+                                [
+                                  {
+                                    "name": "recipe_network_id",
+                                    "type": "varint"
+                                  }
+                                ]
+                              ],
+                              "craft_creative": [
+                                "container",
+                                [
+                                  {
+                                    "name": "creative_item_network_id",
+                                    "type": "varint32"
+                                  }
+                                ]
+                              ],
+                              "optional": [
+                                "container",
+                                [
+                                  {
+                                    "name": "recipe_network_id",
+                                    "type": "varint"
+                                  },
+                                  {
+                                    "name": "filtered_string_index",
+                                    "type": "li32"
+                                  }
+                                ]
+                              ],
+                              "non_implemented": "void",
+                              "results_deprecated": [
+                                "container",
+                                [
+                                  {
+                                    "name": "result_items",
+                                    "type": [
+                                      "array",
+                                      {
+                                        "countType": "varint",
+                                        "type": "Item"
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "name": "times_crafted",
+                                    "type": "u8"
+                                  }
+                                ]
+                              ]
+                            },
+                            "default": "void"
+                          }
+                        ]
+                      }
+                    ]
+                  ]
+                }
+              ]
+            },
+            {
+              "name": "custom_names",
+              "type": [
+                "array",
+                {
+                  "countType": "varint",
+                  "type": "string"
+                }
+              ]
+            }
+          ]
+        ]
+      }
+    ],
+    "ItemStackResponses": [
+      "array",
+      {
+        "countType": "varint",
+        "type": [
+          "container",
+          [
+            {
+              "name": "status",
+              "type": [
+                "mapper",
+                {
+                  "type": "u8",
+                  "mappings": {
+                    "0": "ok",
+                    "1": "error"
+                  }
+                }
+              ]
+            },
+            {
+              "name": "request_id",
+              "type": "varint32"
+            },
+            {
+              "name": "containers",
+              "type": [
+                "array",
+                {
+                  "countType": "varint",
+                  "type": [
+                    "container",
+                    [
+                      {
+                        "name": "slot_type",
+                        "type": "ContainerSlotType"
+                      },
+                      {
+                        "name": "slots",
+                        "type": [
+                          "array",
+                          {
+                            "countType": "varint",
+                            "type": [
+                              "container",
+                              [
+                                {
+                                  "name": "slot",
+                                  "type": "u8"
+                                },
+                                {
+                                  "name": "hotbar_slot",
+                                  "type": "u8"
+                                },
+                                {
+                                  "name": "count",
+                                  "type": "u8"
+                                },
+                                {
+                                  "name": "item_stack_id",
+                                  "type": "varint32"
+                                },
+                                {
+                                  "name": "custom_name",
+                                  "type": "string"
+                                },
+                                {
+                                  "name": "durability_correction",
+                                  "type": "zigzag32"
+                                }
+                              ]
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  ]
+                }
+              ]
+            }
+          ]
+        ]
+      }
+    ],
+    "ItemComponentList": [
+      "array",
+      {
+        "countType": "varint",
+        "type": [
+          "container",
+          [
+            {
+              "name": "name",
+              "type": "string"
+            },
+            {
+              "name": "nbt",
+              "type": "nbt"
+            }
+          ]
+        ]
+      }
+    ],
+    "CommandOrigin": [
+      "container",
+      [
+        {
+          "name": "type",
+          "type": [
+            "mapper",
+            {
+              "type": "varint",
+              "mappings": {
+                "0": "player",
+                "1": "block",
+                "2": "minecart_block",
+                "3": "dev_console",
+                "4": "test",
+                "5": "automation_player",
+                "6": "client_automation",
+                "7": "dedicated_server",
+                "8": "entity",
+                "9": "virtual",
+                "10": "game_argument",
+                "11": "entity_server"
+              }
+            }
+          ]
+        },
+        {
+          "name": "uuid",
+          "type": "uuid"
+        },
+        {
+          "name": "request_id",
+          "type": "string"
+        },
+        {
+          "name": "player_entity_id",
+          "type": [
+            "switch",
+            {
+              "compareTo": "type",
+              "fields": {
+                "dev_console": [
+                  "container",
+                  [
+                    {
+                      "name": "player_entity_id",
+                      "type": "zigzag64"
+                    }
+                  ]
+                ],
+                "test": [
+                  "container",
+                  [
+                    {
+                      "name": "player_entity_id",
+                      "type": "zigzag64"
+                    }
+                  ]
+                ]
+              },
+              "default": "void"
+            }
+          ]
+        }
+      ]
+    ],
+    "WindowID": [
+      "mapper",
+      {
+        "type": "i8",
+        "mappings": {
+          "0": "inventory",
+          "1": "first",
+          "100": "last",
+          "119": "offhand",
+          "120": "armor",
+          "121": "creative",
+          "122": "hotbar",
+          "123": "fixed_inventory",
+          "124": "ui",
+          "-100": "drop_contents",
+          "-24": "beacon",
+          "-23": "trading_output",
+          "-22": "trading_use_inputs",
+          "-21": "trading_input_2",
+          "-20": "trading_input_1",
+          "-17": "enchant_output",
+          "-16": "enchant_material",
+          "-15": "enchant_input",
+          "-13": "anvil_output",
+          "-12": "anvil_result",
+          "-11": "anvil_material",
+          "-10": "container_input",
+          "-5": "crafting_use_ingredient",
+          "-4": "crafting_result",
+          "-3": "crafting_remove_ingredient",
+          "-2": "crafting_add_ingredient",
+          "-1": "none"
+        }
+      }
+    ],
+    "WindowType": [
+      "mapper",
+      {
+        "type": "u8",
+        "mappings": {
+          "0": "container",
+          "1": "workbench",
+          "2": "furnace",
+          "3": "enchantment",
+          "4": "brewing_stand",
+          "5": "anvil",
+          "6": "dispenser",
+          "7": "dropper",
+          "8": "hopper",
+          "9": "cauldron",
+          "10": "minecart_chest",
+          "11": "minecart_hopper",
+          "12": "horse",
+          "13": "beacon",
+          "14": "structure_editor",
+          "15": "trading",
+          "16": "command_block",
+          "17": "jukebox",
+          "18": "armor",
+          "19": "hand",
+          "20": "compound_creator",
+          "21": "element_constructor",
+          "22": "material_reducer",
+          "23": "lab_table",
+          "24": "loom",
+          "25": "lectern",
+          "26": "grindstone",
+          "27": "blast_furnace",
+          "28": "smoker",
+          "29": "stonecutter",
+          "30": "cartography",
+          "31": "hud",
+          "32": "jigsaw_editor",
+          "33": "smithing_table"
+        }
+      }
+    ],
+    "ContainerSlotType": [
+      "mapper",
+      {
+        "type": "u8",
+        "mappings": {
+          "0": "anvil_input",
+          "1": "anvil_material",
+          "2": "anvil_result",
+          "3": "smithing_table_input",
+          "4": "smithing_table_material",
+          "5": "smithing_table_result",
+          "6": "armor",
+          "7": "container",
+          "8": "beacon_payment",
+          "9": "brewing_input",
+          "10": "brewing_result",
+          "11": "brewing_fuel",
+          "12": "hotbar_and_inventory",
+          "13": "crafting_input",
+          "14": "crafting_output",
+          "15": "recipe_construction",
+          "16": "recipe_nature",
+          "17": "recipe_items",
+          "18": "recipe_search",
+          "19": "recipe_search_bar",
+          "20": "recipe_equipment",
+          "21": "enchanting_input",
+          "22": "enchanting_lapis",
+          "23": "furnace_fuel",
+          "24": "furnace_ingredient",
+          "25": "furnace_output",
+          "26": "horse_equip",
+          "27": "hotbar",
+          "28": "inventory",
+          "29": "shulker",
+          "30": "trade_ingredient1",
+          "31": "trade_ingredient2",
+          "32": "trade_result",
+          "33": "offhand",
+          "34": "compcreate_input",
+          "35": "compcreate_output",
+          "36": "elemconstruct_output",
+          "37": "matreduce_input",
+          "38": "matreduce_output",
+          "39": "labtable_input",
+          "40": "loom_input",
+          "41": "loom_dye",
+          "42": "loom_material",
+          "43": "loom_result",
+          "44": "blast_furnace_ingredient",
+          "45": "smoker_ingredient",
+          "46": "trade2_ingredient1",
+          "47": "trade2_ingredient2",
+          "48": "trade2_result",
+          "49": "grindstone_input",
+          "50": "grindstone_additional",
+          "51": "grindstone_result",
+          "52": "stonecutter_input",
+          "53": "stonecutter_result",
+          "54": "cartography_input",
+          "55": "cartography_additional",
+          "56": "cartography_result",
+          "57": "barrel",
+          "58": "cursor",
+          "59": "creative_output"
+        }
+      }
+    ],
+    "LegacyEntityType": [
+      "mapper",
+      {
+        "type": "li32",
+        "mappings": {
+          "10": "chicken",
+          "11": "cow",
+          "12": "pig",
+          "13": "sheep",
+          "14": "wolf",
+          "15": "villager",
+          "16": "mooshroom",
+          "17": "squid",
+          "18": "rabbit",
+          "19": "bat",
+          "20": "iron_golem",
+          "21": "snow_golem",
+          "22": "ocelot",
+          "23": "horse",
+          "24": "donkey",
+          "25": "mule",
+          "26": "skeleton_horse",
+          "27": "zombie_horse",
+          "28": "polar_bear",
+          "29": "llama",
+          "30": "parrot",
+          "31": "dolphin",
+          "32": "zombie",
+          "33": "creeper",
+          "34": "skeleton",
+          "35": "spider",
+          "36": "zombie_pigman",
+          "37": "slime",
+          "38": "enderman",
+          "39": "silverfish",
+          "40": "cave_spider",
+          "41": "ghast",
+          "42": "magma_cube",
+          "43": "blaze",
+          "44": "zombie_villager",
+          "45": "witch",
+          "46": "stray",
+          "47": "husk",
+          "48": "wither_skeleton",
+          "49": "guardian",
+          "50": "elder_guardian",
+          "51": "npc",
+          "52": "wither",
+          "53": "ender_dragon",
+          "54": "shulker",
+          "55": "endermite",
+          "56": "agent",
+          "57": "vindicator",
+          "58": "phantom",
+          "61": "armor_stand",
+          "62": "tripod_camera",
+          "63": "player",
+          "64": "item",
+          "65": "tnt",
+          "66": "falling_block",
+          "67": "moving_block",
+          "68": "xp_bottle",
+          "69": "xp_orb",
+          "70": "eye_of_ender_signal",
+          "71": "ender_crystal",
+          "72": "fireworks_rocket",
+          "73": "thrown_trident",
+          "74": "turtle",
+          "75": "cat",
+          "76": "shulker_bullet",
+          "77": "fishing_hook",
+          "78": "chalkboard",
+          "79": "dragon_fireball",
+          "80": "arrow",
+          "81": "snowball",
+          "82": "egg",
+          "83": "painting",
+          "84": "minecart",
+          "85": "fireball",
+          "86": "splash_potion",
+          "87": "ender_pearl",
+          "88": "leash_knot",
+          "89": "wither_skull",
+          "90": "boat",
+          "91": "wither_skull_dangerous",
+          "93": "lightning_bolt",
+          "94": "small_fireball",
+          "95": "area_effect_cloud",
+          "96": "hopper_minecart",
+          "97": "tnt_minecart",
+          "98": "chest_minecart",
+          "100": "command_block_minecart",
+          "101": "lingering_potion",
+          "102": "llama_spit",
+          "103": "evocation_fang",
+          "104": "evocation_illager",
+          "105": "vex",
+          "106": "ice_bomb",
+          "107": "balloon",
+          "108": "pufferfish",
+          "109": "salmon",
+          "110": "drowned",
+          "111": "tropicalfish",
+          "112": "cod",
+          "113": "panda"
+        }
+      }
+    ],
+    "mcpe_packet": [
+      "container",
+      [
+        {
+          "name": "name",
+          "type": [
+            "mapper",
+            {
+              "type": "varint",
+              "mappings": {
+                "1": "login",
+                "2": "play_status",
+                "3": "server_to_client_handshake",
+                "4": "client_to_server_handshake",
+                "5": "disconnect",
+                "6": "resource_packs_info",
+                "7": "resource_pack_stack",
+                "8": "resource_pack_client_response",
+                "9": "text",
+                "10": "set_time",
+                "11": "start_game",
+                "12": "add_player",
+                "13": "add_entity",
+                "14": "remove_entity",
+                "15": "add_item_entity",
+                "17": "take_item_entity",
+                "18": "move_entity",
+                "19": "move_player",
+                "20": "rider_jump",
+                "21": "update_block",
+                "22": "add_painting",
+                "23": "tick_sync",
+                "24": "level_sound_event_old",
+                "25": "level_event",
+                "26": "block_event",
+                "27": "entity_event",
+                "28": "mob_effect",
+                "29": "update_attributes",
+                "30": "inventory_transaction",
+                "31": "mob_equipment",
+                "32": "mob_armor_equipment",
+                "33": "interact",
+                "34": "block_pick_request",
+                "35": "entity_pick_request",
+                "36": "player_action",
+                "38": "hurt_armor",
+                "39": "set_entity_data",
+                "40": "set_entity_motion",
+                "41": "set_entity_link",
+                "42": "set_health",
+                "43": "set_spawn_position",
+                "44": "animate",
+                "45": "respawn",
+                "46": "container_open",
+                "47": "container_close",
+                "48": "player_hotbar",
+                "49": "inventory_content",
+                "50": "inventory_slot",
+                "51": "container_set_data",
+                "52": "crafting_data",
+                "53": "crafting_event",
+                "54": "gui_data_pick_item",
+                "55": "adventure_settings",
+                "56": "block_entity_data",
+                "57": "player_input",
+                "58": "level_chunk",
+                "59": "set_commands_enabled",
+                "60": "set_difficulty",
+                "61": "change_dimension",
+                "62": "set_player_game_type",
+                "63": "player_list",
+                "64": "simple_event",
+                "65": "event",
+                "66": "spawn_experience_orb",
+                "67": "clientbound_map_item_data",
+                "68": "map_info_request",
+                "69": "request_chunk_radius",
+                "70": "chunk_radius_update",
+                "71": "item_frame_drop_item",
+                "72": "game_rules_changed",
+                "73": "camera",
+                "74": "boss_event",
+                "75": "show_credits",
+                "76": "available_commands",
+                "77": "command_request",
+                "78": "command_block_update",
+                "79": "command_output",
+                "80": "update_trade",
+                "81": "update_equipment",
+                "82": "resource_pack_data_info",
+                "83": "resource_pack_chunk_data",
+                "84": "resource_pack_chunk_request",
+                "85": "transfer",
+                "86": "play_sound",
+                "87": "stop_sound",
+                "88": "set_title",
+                "89": "add_behavior_tree",
+                "90": "structure_block_update",
+                "91": "show_store_offer",
+                "92": "purchase_receipt",
+                "93": "player_skin",
+                "94": "sub_client_login",
+                "95": "initiate_web_socket_connection",
+                "96": "set_last_hurt_by",
+                "97": "book_edit",
+                "98": "npc_request",
+                "99": "photo_transfer",
+                "100": "modal_form_request",
+                "101": "modal_form_response",
+                "102": "server_settings_request",
+                "103": "server_settings_response",
+                "104": "show_profile",
+                "105": "set_default_game_type",
+                "106": "remove_objective",
+                "107": "set_display_objective",
+                "108": "set_score",
+                "109": "lab_table",
+                "110": "update_block_synced",
+                "111": "move_entity_delta",
+                "112": "set_scoreboard_identity",
+                "113": "set_local_player_as_initialized",
+                "114": "update_soft_enum",
+                "115": "network_stack_latency",
+                "117": "script_custom_event",
+                "118": "spawn_particle_effect",
+                "119": "available_entity_identifiers",
+                "120": "level_sound_event_v2",
+                "121": "network_chunk_publisher_update",
+                "122": "biome_definition_list",
+                "123": "level_sound_event",
+                "124": "level_event_generic",
+                "125": "lectern_update",
+                "126": "video_stream_connect",
+                "127": "add_ecs_entity",
+                "128": "remove_ecs_entity",
+                "129": "client_cache_status",
+                "130": "on_screen_texture_animation",
+                "131": "map_create_locked_copy",
+                "132": "structure_template_data_export_request",
+                "133": "structure_template_data_export_response",
+                "134": "update_block_properties",
+                "135": "client_cache_blob_status",
+                "136": "client_cache_miss_response",
+                "137": "education_settings",
+                "139": "multiplayer_settings",
+                "140": "settings_command",
+                "141": "anvil_damage",
+                "142": "completed_using_item",
+                "143": "network_settings",
+                "144": "player_auth_input",
+                "145": "creative_content",
+                "146": "player_enchant_options",
+                "147": "item_stack_request",
+                "148": "item_stack_response",
+                "149": "player_armor_damage",
+                "151": "update_player_game_type",
+                "153": "position_tracking_db_broadcast",
+                "154": "position_tracking_db_request",
+                "156": "packet_violation_warning",
+                "157": "motion_prediction_hints",
+                "158": "animate_entity",
+                "159": "camera_shake",
+                "160": "player_fog",
+                "161": "correct_player_move_prediction",
+                "162": "item_component",
+                "163": "filter_text_packet",
+                "164": "debug_renderer"
+              }
+            }
+          ]
+        },
+        {
+          "name": "params",
+          "type": [
+            "switch",
+            {
+              "compareTo": "name",
+              "fields": {
+                "login": "packet_login",
+                "play_status": "packet_play_status",
+                "server_to_client_handshake": "packet_server_to_client_handshake",
+                "client_to_server_handshake": "packet_client_to_server_handshake",
+                "disconnect": "packet_disconnect",
+                "resource_packs_info": "packet_resource_packs_info",
+                "resource_pack_stack": "packet_resource_pack_stack",
+                "resource_pack_client_response": "packet_resource_pack_client_response",
+                "text": "packet_text",
+                "set_time": "packet_set_time",
+                "start_game": "packet_start_game",
+                "add_player": "packet_add_player",
+                "add_entity": "packet_add_entity",
+                "remove_entity": "packet_remove_entity",
+                "add_item_entity": "packet_add_item_entity",
+                "take_item_entity": "packet_take_item_entity",
+                "move_entity": "packet_move_entity",
+                "move_player": "packet_move_player",
+                "rider_jump": "packet_rider_jump",
+                "update_block": "packet_update_block",
+                "add_painting": "packet_add_painting",
+                "tick_sync": "packet_tick_sync",
+                "level_sound_event_old": "packet_level_sound_event_old",
+                "level_event": "packet_level_event",
+                "block_event": "packet_block_event",
+                "entity_event": "packet_entity_event",
+                "mob_effect": "packet_mob_effect",
+                "update_attributes": "packet_update_attributes",
+                "inventory_transaction": "packet_inventory_transaction",
+                "mob_equipment": "packet_mob_equipment",
+                "mob_armor_equipment": "packet_mob_armor_equipment",
+                "interact": "packet_interact",
+                "block_pick_request": "packet_block_pick_request",
+                "entity_pick_request": "packet_entity_pick_request",
+                "player_action": "packet_player_action",
+                "hurt_armor": "packet_hurt_armor",
+                "set_entity_data": "packet_set_entity_data",
+                "set_entity_motion": "packet_set_entity_motion",
+                "set_entity_link": "packet_set_entity_link",
+                "set_health": "packet_set_health",
+                "set_spawn_position": "packet_set_spawn_position",
+                "animate": "packet_animate",
+                "respawn": "packet_respawn",
+                "container_open": "packet_container_open",
+                "container_close": "packet_container_close",
+                "player_hotbar": "packet_player_hotbar",
+                "inventory_content": "packet_inventory_content",
+                "inventory_slot": "packet_inventory_slot",
+                "container_set_data": "packet_container_set_data",
+                "crafting_data": "packet_crafting_data",
+                "crafting_event": "packet_crafting_event",
+                "gui_data_pick_item": "packet_gui_data_pick_item",
+                "adventure_settings": "packet_adventure_settings",
+                "block_entity_data": "packet_block_entity_data",
+                "player_input": "packet_player_input",
+                "level_chunk": "packet_level_chunk",
+                "set_commands_enabled": "packet_set_commands_enabled",
+                "set_difficulty": "packet_set_difficulty",
+                "change_dimension": "packet_change_dimension",
+                "set_player_game_type": "packet_set_player_game_type",
+                "player_list": "packet_player_list",
+                "simple_event": "packet_simple_event",
+                "event": "packet_event",
+                "spawn_experience_orb": "packet_spawn_experience_orb",
+                "clientbound_map_item_data": "packet_clientbound_map_item_data",
+                "map_info_request": "packet_map_info_request",
+                "request_chunk_radius": "packet_request_chunk_radius",
+                "chunk_radius_update": "packet_chunk_radius_update",
+                "item_frame_drop_item": "packet_item_frame_drop_item",
+                "game_rules_changed": "packet_game_rules_changed",
+                "camera": "packet_camera",
+                "boss_event": "packet_boss_event",
+                "show_credits": "packet_show_credits",
+                "available_commands": "packet_available_commands",
+                "command_request": "packet_command_request",
+                "command_block_update": "packet_command_block_update",
+                "command_output": "packet_command_output",
+                "update_trade": "packet_update_trade",
+                "update_equipment": "packet_update_equipment",
+                "resource_pack_data_info": "packet_resource_pack_data_info",
+                "resource_pack_chunk_data": "packet_resource_pack_chunk_data",
+                "resource_pack_chunk_request": "packet_resource_pack_chunk_request",
+                "transfer": "packet_transfer",
+                "play_sound": "packet_play_sound",
+                "stop_sound": "packet_stop_sound",
+                "set_title": "packet_set_title",
+                "add_behavior_tree": "packet_add_behavior_tree",
+                "structure_block_update": "packet_structure_block_update",
+                "show_store_offer": "packet_show_store_offer",
+                "purchase_receipt": "packet_purchase_receipt",
+                "player_skin": "packet_player_skin",
+                "sub_client_login": "packet_sub_client_login",
+                "initiate_web_socket_connection": "packet_initiate_web_socket_connection",
+                "set_last_hurt_by": "packet_set_last_hurt_by",
+                "book_edit": "packet_book_edit",
+                "npc_request": "packet_npc_request",
+                "photo_transfer": "packet_photo_transfer",
+                "modal_form_request": "packet_modal_form_request",
+                "modal_form_response": "packet_modal_form_response",
+                "server_settings_request": "packet_server_settings_request",
+                "server_settings_response": "packet_server_settings_response",
+                "show_profile": "packet_show_profile",
+                "set_default_game_type": "packet_set_default_game_type",
+                "remove_objective": "packet_remove_objective",
+                "set_display_objective": "packet_set_display_objective",
+                "set_score": "packet_set_score",
+                "lab_table": "packet_lab_table",
+                "update_block_synced": "packet_update_block_synced",
+                "move_entity_delta": "packet_move_entity_delta",
+                "set_scoreboard_identity": "packet_set_scoreboard_identity",
+                "set_local_player_as_initialized": "packet_set_local_player_as_initialized",
+                "update_soft_enum": "packet_update_soft_enum",
+                "network_stack_latency": "packet_network_stack_latency",
+                "script_custom_event": "packet_script_custom_event",
+                "spawn_particle_effect": "packet_spawn_particle_effect",
+                "available_entity_identifiers": "packet_available_entity_identifiers",
+                "level_sound_event_v2": "packet_level_sound_event_v2",
+                "network_chunk_publisher_update": "packet_network_chunk_publisher_update",
+                "biome_definition_list": "packet_biome_definition_list",
+                "level_sound_event": "packet_level_sound_event",
+                "level_event_generic": "packet_level_event_generic",
+                "lectern_update": "packet_lectern_update",
+                "video_stream_connect": "packet_video_stream_connect",
+                "add_ecs_entity": "packet_add_ecs_entity",
+                "remove_ecs_entity": "packet_remove_ecs_entity",
+                "client_cache_status": "packet_client_cache_status",
+                "on_screen_texture_animation": "packet_on_screen_texture_animation",
+                "map_create_locked_copy": "packet_map_create_locked_copy",
+                "structure_template_data_export_request": "packet_structure_template_data_export_request",
+                "structure_template_data_export_response": "packet_structure_template_data_export_response",
+                "update_block_properties": "packet_update_block_properties",
+                "client_cache_blob_status": "packet_client_cache_blob_status",
+                "client_cache_miss_response": "packet_client_cache_miss_response",
+                "education_settings": "packet_education_settings",
+                "multiplayer_settings": "packet_multiplayer_settings",
+                "settings_command": "packet_settings_command",
+                "anvil_damage": "packet_anvil_damage",
+                "completed_using_item": "packet_completed_using_item",
+                "network_settings": "packet_network_settings",
+                "player_auth_input": "packet_player_auth_input",
+                "creative_content": "packet_creative_content",
+                "player_enchant_options": "packet_player_enchant_options",
+                "item_stack_request": "packet_item_stack_request",
+                "item_stack_response": "packet_item_stack_response",
+                "player_armor_damage": "packet_player_armor_damage",
+                "update_player_game_type": "packet_update_player_game_type",
+                "position_tracking_db_request": "packet_position_tracking_db_request",
+                "position_tracking_db_broadcast": "packet_position_tracking_db_broadcast",
+                "packet_violation_warning": "packet_packet_violation_warning",
+                "motion_prediction_hints": "packet_motion_prediction_hints",
+                "animate_entity": "packet_animate_entity",
+                "camera_shake": "packet_camera_shake",
+                "player_fog": "packet_player_fog",
+                "correct_player_move_prediction": "packet_correct_player_move_prediction",
+                "item_component": "packet_item_component",
+                "filter_text_packet": "packet_filter_text_packet",
+                "debug_renderer": "packet_debug_renderer"
+              },
+              "default": "void"
+            }
+          ]
+        }
+      ]
+    ],
+    "packet_login": [
+      "container",
+      [
+        {
+          "name": "protocol_version",
+          "type": "i32"
+        },
+        {
+          "name": "payload_size",
+          "type": "varint"
+        },
+        {
+          "name": "chain",
+          "type": "LittleString"
+        },
+        {
+          "name": "client_data",
+          "type": "LittleString"
+        }
+      ]
+    ],
+    "packet_play_status": [
+      "container",
+      [
+        {
+          "name": "status",
+          "type": [
+            "mapper",
+            {
+              "type": "i32",
+              "mappings": {
+                "0": "login_success",
+                "1": "failed_client",
+                "2": "failed_spawn",
+                "3": "player_spawn",
+                "4": "failed_invalid_tenant",
+                "5": "failed_vanilla_edu",
+                "6": "failed_edu_vanilla",
+                "7": "failed_server_full"
+              }
+            }
+          ]
+        }
+      ]
+    ],
+    "packet_server_to_client_handshake": [
+      "container",
+      [
+        {
+          "name": "token",
+          "type": "string"
+        }
+      ]
+    ],
+    "packet_client_to_server_handshake": [
+      "container",
+      []
+    ],
+    "packet_disconnect": [
+      "container",
+      [
+        {
+          "name": "hide_disconnect_reason",
+          "type": "bool"
+        },
+        {
+          "name": "message",
+          "type": "string"
+        }
+      ]
+    ],
+    "packet_resource_packs_info": [
+      "container",
+      [
+        {
+          "name": "must_accept",
+          "type": "bool"
+        },
+        {
+          "name": "has_scripts",
+          "type": "bool"
+        },
+        {
+          "name": "behaviour_packs",
+          "type": "BehaviourPackInfos"
+        },
+        {
+          "name": "texture_packs",
+          "type": "TexturePackInfos"
+        }
+      ]
+    ],
+    "packet_resource_pack_stack": [
+      "container",
+      [
+        {
+          "name": "must_accept",
+          "type": "bool"
+        },
+        {
+          "name": "behavior_packs",
+          "type": "ResourcePackIdVersions"
+        },
+        {
+          "name": "resource_packs",
+          "type": "ResourcePackIdVersions"
+        },
+        {
+          "name": "game_version",
+          "type": "string"
+        },
+        {
+          "name": "experiments",
+          "type": "Experiments"
+        },
+        {
+          "name": "experiments_previously_used",
+          "type": "bool"
+        }
+      ]
+    ],
+    "packet_resource_pack_client_response": [
+      "container",
+      [
+        {
+          "name": "response_status",
+          "type": [
+            "mapper",
+            {
+              "type": "u8",
+              "mappings": {
+                "0": "none",
+                "1": "refused",
+                "2": "send_packs",
+                "3": "have_all_packs",
+                "4": "completed"
+              }
+            }
+          ]
+        },
+        {
+          "name": "resourcepackids",
+          "type": "ResourcePackIds"
+        }
+      ]
+    ],
+    "packet_text": [
+      "container",
+      [
+        {
+          "name": "type",
+          "type": [
+            "mapper",
+            {
+              "type": "u8",
+              "mappings": {
+                "0": "raw",
+                "1": "chat",
+                "2": "translation",
+                "3": "popup",
+                "4": "jukebox_popup",
+                "5": "tip",
+                "6": "system",
+                "7": "whisper",
+                "8": "announcement",
+                "9": "json_whisper",
+                "10": "json"
+              }
+            }
+          ]
+        },
+        {
+          "name": "needs_translation",
+          "type": "bool"
+        },
+        {
+          "anon": true,
+          "type": [
+            "switch",
+            {
+              "compareTo": "type",
+              "fields": {
+                "chat": [
+                  "container",
+                  [
+                    {
+                      "name": "source_name",
+                      "type": "string"
+                    },
+                    {
+                      "name": "message",
+                      "type": "string"
+                    }
+                  ]
+                ],
+                "whisper": [
+                  "container",
+                  [
+                    {
+                      "name": "source_name",
+                      "type": "string"
+                    },
+                    {
+                      "name": "message",
+                      "type": "string"
+                    }
+                  ]
+                ],
+                "announcement": [
+                  "container",
+                  [
+                    {
+                      "name": "source_name",
+                      "type": "string"
+                    },
+                    {
+                      "name": "message",
+                      "type": "string"
+                    }
+                  ]
+                ],
+                "raw": [
+                  "container",
+                  [
+                    {
+                      "name": "message",
+                      "type": "string"
+                    }
+                  ]
+                ],
+                "tip": [
+                  "container",
+                  [
+                    {
+                      "name": "message",
+                      "type": "string"
+                    }
+                  ]
+                ],
+                "system": [
+                  "container",
+                  [
+                    {
+                      "name": "message",
+                      "type": "string"
+                    }
+                  ]
+                ],
+                "json_whisper": [
+                  "container",
+                  [
+                    {
+                      "name": "message",
+                      "type": "string"
+                    }
+                  ]
+                ],
+                "json": [
+                  "container",
+                  [
+                    {
+                      "name": "message",
+                      "type": "string"
+                    }
+                  ]
+                ],
+                "translation": [
+                  "container",
+                  [
+                    {
+                      "name": "message",
+                      "type": "string"
+                    },
+                    {
+                      "name": "paramaters",
+                      "type": [
+                        "array",
+                        {
+                          "countType": "varint",
+                          "type": "string"
+                        }
+                      ]
+                    }
+                  ]
+                ],
+                "popup": [
+                  "container",
+                  [
+                    {
+                      "name": "message",
+                      "type": "string"
+                    },
+                    {
+                      "name": "paramaters",
+                      "type": [
+                        "array",
+                        {
+                          "countType": "varint",
+                          "type": "string"
+                        }
+                      ]
+                    }
+                  ]
+                ],
+                "jukebox_popup": [
+                  "container",
+                  [
+                    {
+                      "name": "message",
+                      "type": "string"
+                    },
+                    {
+                      "name": "paramaters",
+                      "type": [
+                        "array",
+                        {
+                          "countType": "varint",
+                          "type": "string"
+                        }
+                      ]
+                    }
+                  ]
+                ]
+              },
+              "default": "void"
+            }
+          ]
+        },
+        {
+          "name": "xuid",
+          "type": "string"
+        },
+        {
+          "name": "platform_chat_id",
+          "type": "string"
+        }
+      ]
+    ],
+    "packet_set_time": [
+      "container",
+      [
+        {
+          "name": "time",
+          "type": "zigzag32"
+        }
+      ]
+    ],
+    "packet_start_game": [
+      "container",
+      [
+        {
+          "name": "entity_id",
+          "type": "zigzag64"
+        },
+        {
+          "name": "runtime_entity_id",
+          "type": "varint64"
+        },
+        {
+          "name": "player_gamemode",
+          "type": "GameMode"
+        },
+        {
+          "name": "player_position",
+          "type": "vec3f"
+        },
+        {
+          "name": "rotation",
+          "type": "vec2f"
+        },
+        {
+          "name": "seed",
+          "type": "zigzag32"
+        },
+        {
+          "name": "biome_type",
+          "type": "li16"
+        },
+        {
+          "name": "biome_name",
+          "type": "string"
+        },
+        {
+          "name": "dimension",
+          "type": "zigzag32"
+        },
+        {
+          "name": "generator",
+          "type": "zigzag32"
+        },
+        {
+          "name": "world_gamemode",
+          "type": "GameMode"
+        },
+        {
+          "name": "difficulty",
+          "type": "zigzag32"
+        },
+        {
+          "name": "spawn_position",
+          "type": "BlockCoordinates"
+        },
+        {
+          "name": "achievements_disabled",
+          "type": "bool"
+        },
+        {
+          "name": "day_cycle_stop_time",
+          "type": "zigzag32"
+        },
+        {
+          "name": "edu_offer",
+          "type": "zigzag32"
+        },
+        {
+          "name": "edu_features_enabled",
+          "type": "bool"
+        },
+        {
+          "name": "edu_product_uuid",
+          "type": "string"
+        },
+        {
+          "name": "rain_level",
+          "type": "lf32"
+        },
+        {
+          "name": "lightning_level",
+          "type": "lf32"
+        },
+        {
+          "name": "has_confirmed_platform_locked_content",
+          "type": "bool"
+        },
+        {
+          "name": "is_multiplayer",
+          "type": "bool"
+        },
+        {
+          "name": "broadcast_to_lan",
+          "type": "bool"
+        },
+        {
+          "name": "xbox_live_broadcast_mode",
+          "type": "varint"
+        },
+        {
+          "name": "platform_broadcast_mode",
+          "type": "varint"
+        },
+        {
+          "name": "enable_commands",
+          "type": "bool"
+        },
+        {
+          "name": "is_texturepacks_required",
+          "type": "bool"
+        },
+        {
+          "name": "gamerules",
+          "type": "GameRules"
+        },
+        {
+          "name": "experiments",
+          "type": "Experiments"
+        },
+        {
+          "name": "experiments_previously_used",
+          "type": "bool"
+        },
+        {
+          "name": "bonus_chest",
+          "type": "bool"
+        },
+        {
+          "name": "map_enabled",
+          "type": "bool"
+        },
+        {
+          "name": "permission_level",
+          "type": "zigzag32"
+        },
+        {
+          "name": "server_chunk_tick_range",
+          "type": "li32"
+        },
+        {
+          "name": "has_locked_behavior_pack",
+          "type": "bool"
+        },
+        {
+          "name": "has_locked_resource_pack",
+          "type": "bool"
+        },
+        {
+          "name": "is_from_locked_world_template",
+          "type": "bool"
+        },
+        {
+          "name": "msa_gamertags_only",
+          "type": "bool"
+        },
+        {
+          "name": "is_from_world_template",
+          "type": "bool"
+        },
+        {
+          "name": "is_world_template_option_locked",
+          "type": "bool"
+        },
+        {
+          "name": "only_spawn_v1_villagers",
+          "type": "bool"
+        },
+        {
+          "name": "game_version",
+          "type": "string"
+        },
+        {
+          "name": "limited_world_width",
+          "type": "li32"
+        },
+        {
+          "name": "limited_world_length",
+          "type": "li32"
+        },
+        {
+          "name": "is_new_nether",
+          "type": "bool"
+        },
+        {
+          "name": "experimental_gameplay_override",
+          "type": "bool"
+        },
+        {
+          "name": "level_id",
+          "type": "string"
+        },
+        {
+          "name": "world_name",
+          "type": "string"
+        },
+        {
+          "name": "premium_world_template_id",
+          "type": "string"
+        },
+        {
+          "name": "is_trial",
+          "type": "bool"
+        },
+        {
+          "name": "movement_authority",
+          "type": [
+            "mapper",
+            {
+              "type": "zigzag32",
+              "mappings": {
+                "0": "client",
+                "1": "server",
+                "2": "server_with_rewind"
+              }
+            }
+          ]
+        },
+        {
+          "name": "rewind_history_size",
+          "type": "zigzag32"
+        },
+        {
+          "name": "server_authoritative_block_breaking",
+          "type": "bool"
+        },
+        {
+          "name": "current_tick",
+          "type": "li64"
+        },
+        {
+          "name": "enchantment_seed",
+          "type": "zigzag32"
+        },
+        {
+          "name": "block_palette",
+          "type": "BlockPalette"
+        },
+        {
+          "name": "itemstates",
+          "type": "Itemstates"
+        },
+        {
+          "name": "multiplayer_correlation_id",
+          "type": "string"
+        },
+        {
+          "name": "server_authoritative_inventory",
+          "type": "bool"
+        }
+      ]
+    ],
+    "packet_add_player": [
+      "container",
+      [
+        {
+          "name": "uuid",
+          "type": "uuid"
+        },
+        {
+          "name": "username",
+          "type": "string"
+        },
+        {
+          "name": "entity_id_self",
+          "type": "zigzag64"
+        },
+        {
+          "name": "runtime_entity_id",
+          "type": "varint"
+        },
+        {
+          "name": "platform_chat_id",
+          "type": "string"
+        },
+        {
+          "name": "x",
+          "type": "lf32"
+        },
+        {
+          "name": "y",
+          "type": "lf32"
+        },
+        {
+          "name": "z",
+          "type": "lf32"
+        },
+        {
+          "name": "speed_x",
+          "type": "lf32"
+        },
+        {
+          "name": "speed_y",
+          "type": "lf32"
+        },
+        {
+          "name": "speed_z",
+          "type": "lf32"
+        },
+        {
+          "name": "pitch",
+          "type": "lf32"
+        },
+        {
+          "name": "yaw",
+          "type": "lf32"
+        },
+        {
+          "name": "head_yaw",
+          "type": "lf32"
+        },
+        {
+          "name": "held_item",
+          "type": "Item"
+        },
+        {
+          "name": "metadata",
+          "type": "MetadataDictionary"
+        },
+        {
+          "name": "flags",
+          "type": "varint"
+        },
+        {
+          "name": "command_permission",
+          "type": "varint"
+        },
+        {
+          "name": "action_permissions",
+          "type": "varint"
+        },
+        {
+          "name": "permission_level",
+          "type": "varint"
+        },
+        {
+          "name": "custom_stored_permissions",
+          "type": "varint"
+        },
+        {
+          "name": "user_id",
+          "type": "li64"
+        },
+        {
+          "name": "links",
+          "type": "Links"
+        },
+        {
+          "name": "device_id",
+          "type": "string"
+        },
+        {
+          "name": "device_os",
+          "type": "li32"
+        }
+      ]
+    ],
+    "packet_add_entity": [
+      "container",
+      [
+        {
+          "name": "entity_id_self",
+          "type": "zigzag64"
+        },
+        {
+          "name": "runtime_entity_id",
+          "type": "varint"
+        },
+        {
+          "name": "entity_type",
+          "type": "string"
+        },
+        {
+          "name": "x",
+          "type": "lf32"
+        },
+        {
+          "name": "y",
+          "type": "lf32"
+        },
+        {
+          "name": "z",
+          "type": "lf32"
+        },
+        {
+          "name": "speed_x",
+          "type": "lf32"
+        },
+        {
+          "name": "speed_y",
+          "type": "lf32"
+        },
+        {
+          "name": "speed_z",
+          "type": "lf32"
+        },
+        {
+          "name": "pitch",
+          "type": "lf32"
+        },
+        {
+          "name": "yaw",
+          "type": "lf32"
+        },
+        {
+          "name": "head_yaw",
+          "type": "lf32"
+        },
+        {
+          "name": "attributes",
+          "type": "EntityAttributes"
+        },
+        {
+          "name": "metadata",
+          "type": "MetadataDictionary"
+        },
+        {
+          "name": "links",
+          "type": "Links"
+        }
+      ]
+    ],
+    "packet_remove_entity": [
+      "container",
+      [
+        {
+          "name": "entity_id_self",
+          "type": "zigzag64"
+        }
+      ]
+    ],
+    "packet_add_item_entity": [
+      "container",
+      [
+        {
+          "name": "entity_id_self",
+          "type": "zigzag64"
+        },
+        {
+          "name": "runtime_entity_id",
+          "type": "varint"
+        },
+        {
+          "name": "item",
+          "type": "Item"
+        },
+        {
+          "name": "x",
+          "type": "lf32"
+        },
+        {
+          "name": "y",
+          "type": "lf32"
+        },
+        {
+          "name": "z",
+          "type": "lf32"
+        },
+        {
+          "name": "speed_x",
+          "type": "lf32"
+        },
+        {
+          "name": "speed_y",
+          "type": "lf32"
+        },
+        {
+          "name": "speed_z",
+          "type": "lf32"
+        },
+        {
+          "name": "metadata",
+          "type": "MetadataDictionary"
+        },
+        {
+          "name": "is_from_fishing",
+          "type": "bool"
+        }
+      ]
+    ],
+    "packet_take_item_entity": [
+      "container",
+      [
+        {
+          "name": "runtime_entity_id",
+          "type": "varint"
+        },
+        {
+          "name": "target",
+          "type": "varint"
+        }
+      ]
+    ],
+    "packet_move_entity": [
+      "container",
+      [
+        {
+          "name": "runtime_entity_id",
+          "type": "varint"
+        },
+        {
+          "name": "flags",
+          "type": "u8"
+        },
+        {
+          "name": "position",
+          "type": "vec3f"
+        },
+        {
+          "name": "rotation",
+          "type": "Rotation"
+        }
+      ]
+    ],
+    "packet_move_player": [
+      "container",
+      [
+        {
+          "name": "runtime_id",
+          "type": "varint"
+        },
+        {
+          "name": "position",
+          "type": "vec3f"
+        },
+        {
+          "name": "pitch",
+          "type": "lf32"
+        },
+        {
+          "name": "yaw",
+          "type": "lf32"
+        },
+        {
+          "name": "head_yaw",
+          "type": "lf32"
+        },
+        {
+          "name": "mode",
+          "type": [
+            "mapper",
+            {
+              "type": "u8",
+              "mappings": {
+                "0": "normal",
+                "1": "reset",
+                "2": "teleport",
+                "3": "rotation"
+              }
+            }
+          ]
+        },
+        {
+          "name": "on_ground",
+          "type": "bool"
+        },
+        {
+          "name": "ridden_runtime_id",
+          "type": "varint"
+        },
+        {
+          "name": "teleport",
+          "type": [
+            "switch",
+            {
+              "compareTo": "mode",
+              "fields": {
+                "teleport": [
+                  "container",
+                  [
+                    {
+                      "name": "cause",
+                      "type": [
+                        "mapper",
+                        {
+                          "type": "li32",
+                          "mappings": {
+                            "0": "unknown",
+                            "1": "projectile",
+                            "2": "chorus_fruit",
+                            "3": "command",
+                            "4": "behavior"
+                          }
+                        }
+                      ]
+                    },
+                    {
+                      "name": "source_entity_type",
+                      "type": "LegacyEntityType"
+                    }
+                  ]
+                ]
+              },
+              "default": "void"
+            }
+          ]
+        },
+        {
+          "name": "tick",
+          "type": "varint64"
+        }
+      ]
+    ],
+    "packet_rider_jump": [
+      "container",
+      [
+        {
+          "name": "jump_strength",
+          "type": "zigzag32"
+        }
+      ]
+    ],
+    "packet_update_block": [
+      "container",
+      [
+        {
+          "name": "position",
+          "type": "BlockCoordinates"
+        },
+        {
+          "name": "block_runtime_id",
+          "type": "varint"
+        },
+        {
+          "name": "flags",
+          "type": "UpdateBlockFlags"
+        },
+        {
+          "name": "layer",
+          "type": "varint"
+        }
+      ]
+    ],
+    "packet_add_painting": [
+      "container",
+      [
+        {
+          "name": "entity_id_self",
+          "type": "zigzag64"
+        },
+        {
+          "name": "runtime_entity_id",
+          "type": "varint"
+        },
+        {
+          "name": "coordinates",
+          "type": "BlockCoordinates"
+        },
+        {
+          "name": "direction",
+          "type": "zigzag32"
+        },
+        {
+          "name": "title",
+          "type": "string"
+        }
+      ]
+    ],
+    "packet_tick_sync": [
+      "container",
+      [
+        {
+          "name": "request_time",
+          "type": "li64"
+        },
+        {
+          "name": "response_time",
+          "type": "li64"
+        }
+      ]
+    ],
+    "packet_level_sound_event_old": [
+      "container",
+      [
+        {
+          "name": "sound_id",
+          "type": "u8"
+        },
+        {
+          "name": "position",
+          "type": "vec3f"
+        },
+        {
+          "name": "block_id",
+          "type": "zigzag32"
+        },
+        {
+          "name": "entity_type",
+          "type": "zigzag32"
+        },
+        {
+          "name": "is_baby_mob",
+          "type": "bool"
+        },
+        {
+          "name": "is_global",
+          "type": "bool"
+        }
+      ]
+    ],
+    "packet_level_event": [
+      "container",
+      [
+        {
+          "name": "event",
+          "type": [
+            "mapper",
+            {
+              "type": "zigzag32",
+              "mappings": {
+                "1000": "sound_click",
+                "1001": "sound_click_fail",
+                "1002": "sound_shoot",
+                "1003": "sound_door",
+                "1004": "sound_fizz",
+                "1005": "sound_ignite",
+                "1007": "sound_ghast",
+                "1008": "sound_ghast_shoot",
+                "1009": "sound_blaze_shoot",
+                "1010": "sound_door_bump",
+                "1012": "sound_door_crash",
+                "1018": "sound_enderman_teleport",
+                "1020": "sound_anvil_break",
+                "1021": "sound_anvil_use",
+                "1022": "sound_anvil_fall",
+                "1030": "sound_pop",
+                "1032": "sound_portal",
+                "1040": "sound_itemframe_add_item",
+                "1041": "sound_itemframe_remove",
+                "1042": "sound_itemframe_place",
+                "1043": "sound_itemframe_remove_item",
+                "1044": "sound_itemframe_rotate_item",
+                "1050": "sound_camera",
+                "1051": "sound_orb",
+                "1052": "sound_totem",
+                "1060": "sound_armor_stand_break",
+                "1061": "sound_armor_stand_hit",
+                "1062": "sound_armor_stand_fall",
+                "1063": "sound_armor_stand_place",
+                "2000": "particle_shoot",
+                "2001": "particle_destroy",
+                "2002": "particle_splash",
+                "2003": "particle_eye_despawn",
+                "2004": "particle_spawn",
+                "2006": "guardian_curse",
+                "2008": "particle_block_force_field",
+                "2009": "particle_projectile_hit",
+                "2013": "particle_enderman_teleport",
+                "2014": "particle_punch_block",
+                "3001": "start_rain",
+                "3002": "start_thunder",
+                "3003": "stop_rain",
+                "3004": "stop_thunder",
+                "3005": "pause_game",
+                "3006": "pause_game_no_screen",
+                "3007": "set_game_speed",
+                "3500": "redstone_trigger",
+                "3501": "cauldron_explode",
+                "3502": "cauldron_dye_armor",
+                "3503": "cauldron_clean_armor",
+                "3504": "cauldron_fill_potion",
+                "3505": "cauldron_take_potion",
+                "3506": "cauldron_fill_water",
+                "3507": "cauldron_take_water",
+                "3508": "cauldron_add_dye",
+                "3509": "cauldron_clean_banner",
+                "3600": "block_start_break",
+                "3601": "block_stop_break",
+                "4000": "set_data",
+                "9800": "players_sleeping",
+                "16384": "add_particle_mask"
+              }
+            }
+          ]
+        },
+        {
+          "name": "position",
+          "type": "vec3f"
+        },
+        {
+          "name": "data",
+          "type": "zigzag32"
+        }
+      ]
+    ],
+    "packet_block_event": [
+      "container",
+      [
+        {
+          "name": "position",
+          "type": "BlockCoordinates"
+        },
+        {
+          "name": "type",
+          "type": [
+            "mapper",
+            {
+              "type": "zigzag32",
+              "mappings": {
+                "0": "sound",
+                "1": "change_state"
+              }
+            }
+          ]
+        },
+        {
+          "name": "data",
+          "type": "zigzag32"
+        }
+      ]
+    ],
+    "packet_entity_event": [
+      "container",
+      [
+        {
+          "name": "runtime_entity_id",
+          "type": "varint"
+        },
+        {
+          "name": "event_id",
+          "type": [
+            "mapper",
+            {
+              "type": "u8",
+              "mappings": {
+                "1": "jump",
+                "2": "hurt_animation",
+                "3": "death_animation",
+                "4": "arm_swing",
+                "5": "stop_attack",
+                "6": "tame_fail",
+                "7": "tame_success",
+                "8": "shake_wet",
+                "9": "use_item",
+                "10": "eat_grass_animation",
+                "11": "fish_hook_bubble",
+                "12": "fish_hook_position",
+                "13": "fish_hook_hook",
+                "14": "fish_hook_tease",
+                "15": "squid_ink_cloud",
+                "16": "zombie_villager_cure",
+                "18": "respawn",
+                "19": "iron_golem_offer_flower",
+                "20": "iron_golem_withdraw_flower",
+                "21": "love_particles",
+                "22": "villager_angry",
+                "23": "villager_happy",
+                "24": "witch_spell_particles",
+                "25": "firework_particles",
+                "26": "in_love_particles",
+                "27": "silverfish_spawn_animation",
+                "28": "guardian_attack",
+                "29": "witch_drink_potion",
+                "30": "witch_throw_potion",
+                "31": "minecart_tnt_prime_fuse",
+                "32": "creeper_prime_fuse",
+                "33": "air_supply_expired",
+                "34": "player_add_xp_levels",
+                "35": "elder_guardian_curse",
+                "36": "agent_arm_swing",
+                "37": "ender_dragon_death",
+                "38": "dust_particles",
+                "39": "arrow_shake",
+                "57": "eating_item",
+                "60": "baby_animal_feed",
+                "61": "death_smoke_cloud",
+                "62": "complete_trade",
+                "63": "remove_leash",
+                "65": "consume_totem",
+                "66": "player_check_treasure_hunter_achievement",
+                "67": "entity_spawn",
+                "68": "dragon_puke",
+                "69": "item_entity_merge",
+                "70": "start_swim",
+                "71": "balloon_pop",
+                "72": "treasure_hunt",
+                "73": "agent_summon",
+                "74": "charged_crossbow",
+                "75": "fall"
+              }
+            }
+          ]
+        },
+        {
+          "name": "data",
+          "type": "zigzag32"
+        }
+      ]
+    ],
+    "packet_mob_effect": [
+      "container",
+      [
+        {
+          "name": "runtime_entity_id",
+          "type": "varint"
+        },
+        {
+          "name": "event_id",
+          "type": "u8"
+        },
+        {
+          "name": "effect_id",
+          "type": "zigzag32"
+        },
+        {
+          "name": "amplifier",
+          "type": "zigzag32"
+        },
+        {
+          "name": "particles",
+          "type": "bool"
+        },
+        {
+          "name": "duration",
+          "type": "zigzag32"
+        }
+      ]
+    ],
+    "packet_update_attributes": [
+      "container",
+      [
+        {
+          "name": "runtime_entity_id",
+          "type": "varint64"
+        },
+        {
+          "name": "attributes",
+          "type": "PlayerAttributes"
+        },
+        {
+          "name": "tick",
+          "type": "varint64"
+        }
+      ]
+    ],
+    "packet_inventory_transaction": [
+      "container",
+      [
+        {
+          "name": "transaction",
+          "type": "Transaction"
+        }
+      ]
+    ],
+    "packet_mob_equipment": [
+      "container",
+      [
+        {
+          "name": "runtime_entity_id",
+          "type": "varint"
+        },
+        {
+          "name": "item",
+          "type": "Item"
+        },
+        {
+          "name": "slot",
+          "type": "u8"
+        },
+        {
+          "name": "selected_slot",
+          "type": "u8"
+        },
+        {
+          "name": "windows_id",
+          "type": "WindowID"
+        }
+      ]
+    ],
+    "packet_mob_armor_equipment": [
+      "container",
+      [
+        {
+          "name": "runtime_entity_id",
+          "type": "varint"
+        },
+        {
+          "name": "helmet",
+          "type": "Item"
+        },
+        {
+          "name": "chestplate",
+          "type": "Item"
+        },
+        {
+          "name": "leggings",
+          "type": "Item"
+        },
+        {
+          "name": "boots",
+          "type": "Item"
+        }
+      ]
+    ],
+    "packet_interact": [
+      "container",
+      [
+        {
+          "name": "action_id",
+          "type": [
+            "mapper",
+            {
+              "type": "u8",
+              "mappings": {
+                "3": "leave_vehicle",
+                "4": "mouse_over_entity",
+                "6": "open_inventory"
+              }
+            }
+          ]
+        },
+        {
+          "name": "target_runtime_entity_id",
+          "type": "varint"
+        },
+        {
+          "name": "position",
+          "type": [
+            "switch",
+            {
+              "compareTo": "action_id",
+              "fields": {
+                "mouse_over_entity": "vec3f",
+                "leave_vehicle": "vec3f"
+              },
+              "default": "void"
+            }
+          ]
+        }
+      ]
+    ],
+    "packet_block_pick_request": [
+      "container",
+      [
+        {
+          "name": "x",
+          "type": "zigzag32"
+        },
+        {
+          "name": "y",
+          "type": "zigzag32"
+        },
+        {
+          "name": "z",
+          "type": "zigzag32"
+        },
+        {
+          "name": "add_user_data",
+          "type": "bool"
+        },
+        {
+          "name": "selected_slot",
+          "type": "u8"
+        }
+      ]
+    ],
+    "packet_entity_pick_request": [
+      "container",
+      [
+        {
+          "name": "runtime_entity_id",
+          "type": "lu64"
+        },
+        {
+          "name": "selected_slot",
+          "type": "u8"
+        }
+      ]
+    ],
+    "packet_player_action": [
+      "container",
+      [
+        {
+          "name": "runtime_entity_id",
+          "type": "varint"
+        },
+        {
+          "name": "action",
+          "type": [
+            "mapper",
+            {
+              "type": "zigzag32",
+              "mappings": {
+                "0": "start_break",
+                "1": "abort_break",
+                "2": "stop_break",
+                "3": "get_updated_block",
+                "4": "drop_item",
+                "5": "start_sleeping",
+                "6": "stop_sleeping",
+                "7": "respawn",
+                "8": "jump",
+                "9": "start_sprint",
+                "10": "stop_sprint",
+                "11": "start_sneak",
+                "12": "stop_sneak",
+                "13": "creative_player_destroy_block",
+                "14": "dimension_change_ack",
+                "15": "start_glide",
+                "16": "stop_glide",
+                "17": "build_denied",
+                "18": "crack_break",
+                "19": "change_skin",
+                "20": "set_enchatnment_seed",
+                "21": "swimming",
+                "22": "stop_swimming",
+                "23": "start_spin_attack",
+                "24": "stop_spin_attack",
+                "25": "ineract_block",
+                "26": "predict_break",
+                "27": "continue_break"
+              }
+            }
+          ]
+        },
+        {
+          "name": "position",
+          "type": "BlockCoordinates"
+        },
+        {
+          "name": "face",
+          "type": "zigzag32"
+        }
+      ]
+    ],
+    "packet_hurt_armor": [
+      "container",
+      [
+        {
+          "name": "health",
+          "type": "zigzag32"
+        }
+      ]
+    ],
+    "packet_set_entity_data": [
+      "container",
+      [
+        {
+          "name": "runtime_entity_id",
+          "type": "varint"
+        },
+        {
+          "name": "metadata",
+          "type": "MetadataDictionary"
+        },
+        {
+          "name": "tick",
+          "type": "varint"
+        }
+      ]
+    ],
+    "packet_set_entity_motion": [
+      "container",
+      [
+        {
+          "name": "runtime_entity_id",
+          "type": "varint"
+        },
+        {
+          "name": "velocity",
+          "type": "vec3f"
+        }
+      ]
+    ],
+    "packet_set_entity_link": [
+      "container",
+      [
+        {
+          "name": "link",
+          "type": "Link"
+        }
+      ]
+    ],
+    "packet_set_health": [
+      "container",
+      [
+        {
+          "name": "health",
+          "type": "zigzag32"
+        }
+      ]
+    ],
+    "packet_set_spawn_position": [
+      "container",
+      [
+        {
+          "name": "spawn_type",
+          "type": [
+            "mapper",
+            {
+              "type": "zigzag32",
+              "mappings": {
+                "0": "player",
+                "1": "world"
+              }
+            }
+          ]
+        },
+        {
+          "name": "player_position",
+          "type": "BlockCoordinates"
+        },
+        {
+          "name": "dimension",
+          "type": "zigzag32"
+        },
+        {
+          "name": "world_position",
+          "type": "BlockCoordinates"
+        }
+      ]
+    ],
+    "packet_animate": [
+      "container",
+      [
+        {
+          "name": "action_id",
+          "type": "zigzag32"
+        },
+        {
+          "name": "runtime_entity_id",
+          "type": "varint"
+        }
+      ]
+    ],
+    "packet_respawn": [
+      "container",
+      [
+        {
+          "name": "x",
+          "type": "lf32"
+        },
+        {
+          "name": "y",
+          "type": "lf32"
+        },
+        {
+          "name": "z",
+          "type": "lf32"
+        },
+        {
+          "name": "state",
+          "type": "u8"
+        },
+        {
+          "name": "runtime_entity_id",
+          "type": "varint"
+        }
+      ]
+    ],
+    "packet_container_open": [
+      "container",
+      [
+        {
+          "name": "window_id",
+          "type": "u8"
+        },
+        {
+          "name": "window_type",
+          "type": "WindowType"
+        },
+        {
+          "name": "coordinates",
+          "type": "BlockCoordinates"
+        },
+        {
+          "name": "runtime_entity_id",
+          "type": "zigzag64"
+        }
+      ]
+    ],
+    "packet_container_close": [
+      "container",
+      [
+        {
+          "name": "window_id",
+          "type": "u8"
+        },
+        {
+          "name": "server",
+          "type": "bool"
+        }
+      ]
+    ],
+    "packet_player_hotbar": [
+      "container",
+      [
+        {
+          "name": "selected_slot",
+          "type": "varint"
+        },
+        {
+          "name": "window_id",
+          "type": "WindowID"
+        },
+        {
+          "name": "select_slot",
+          "type": "bool"
+        }
+      ]
+    ],
+    "packet_inventory_content": [
+      "container",
+      [
+        {
+          "name": "inventory_id",
+          "type": "varint"
+        },
+        {
+          "name": "input",
+          "type": "ItemStacks"
+        }
+      ]
+    ],
+    "packet_inventory_slot": [
+      "container",
+      [
+        {
+          "name": "window_id",
+          "type": "varint"
+        },
+        {
+          "name": "slot",
+          "type": "varint"
+        },
+        {
+          "name": "item",
+          "type": "ItemStack"
+        }
+      ]
+    ],
+    "packet_container_set_data": [
+      "container",
+      [
+        {
+          "name": "window_id",
+          "type": "WindowID"
+        },
+        {
+          "name": "property",
+          "type": "zigzag32"
+        },
+        {
+          "name": "value",
+          "type": "zigzag32"
+        }
+      ]
+    ],
+    "packet_crafting_data": [
+      "container",
+      [
+        {
+          "name": "recipes",
+          "type": "Recipes"
+        },
+        {
+          "name": "potion_type_recipes",
+          "type": "PotionTypeRecipes"
+        },
+        {
+          "name": "potion_container_recipes",
+          "type": "PotionContainerChangeRecipes"
+        },
+        {
+          "name": "is_clean",
+          "type": "bool"
+        }
+      ]
+    ],
+    "packet_crafting_event": [
+      "container",
+      [
+        {
+          "name": "window_id",
+          "type": "WindowID"
+        },
+        {
+          "name": "recipe_type",
+          "type": [
+            "mapper",
+            {
+              "type": "zigzag32",
+              "mappings": {
+                "0": "inventory",
+                "1": "crafting",
+                "2": "workbench"
+              }
+            }
+          ]
+        },
+        {
+          "name": "recipe_id",
+          "type": "uuid"
+        },
+        {
+          "name": "input",
+          "type": [
+            "array",
+            {
+              "countType": "varint",
+              "type": "Item"
+            }
+          ]
+        },
+        {
+          "name": "result",
+          "type": [
+            "array",
+            {
+              "countType": "varint",
+              "type": "Item"
+            }
+          ]
+        }
+      ]
+    ],
+    "packet_gui_data_pick_item": [
+      "container",
+      []
+    ],
+    "packet_adventure_settings": [
+      "container",
+      [
+        {
+          "name": "flags",
+          "type": "AdventureFlags"
+        },
+        {
+          "name": "command_permission",
+          "type": [
+            "mapper",
+            {
+              "type": "varint32",
+              "mappings": {
+                "0": "normal",
+                "1": "operator",
+                "2": "host",
+                "3": "automation",
+                "4": "admin"
+              }
+            }
+          ]
+        },
+        {
+          "name": "action_permissions",
+          "type": "ActionPermissions"
+        },
+        {
+          "name": "permission_level",
+          "type": [
+            "mapper",
+            {
+              "type": "varint",
+              "mappings": {
+                "0": "visitor",
+                "1": "member",
+                "2": "operator",
+                "3": "custom"
+              }
+            }
+          ]
+        },
+        {
+          "name": "custom_stored_permissions",
+          "type": "varint"
+        },
+        {
+          "name": "user_id",
+          "type": "li64"
+        }
+      ]
+    ],
+    "packet_block_entity_data": [
+      "container",
+      [
+        {
+          "name": "position",
+          "type": "BlockCoordinates"
+        },
+        {
+          "name": "nbt",
+          "type": "nbt"
+        }
+      ]
+    ],
+    "packet_player_input": [
+      "container",
+      [
+        {
+          "name": "motion_x",
+          "type": "lf32"
+        },
+        {
+          "name": "motion_z",
+          "type": "lf32"
+        },
+        {
+          "name": "jumping",
+          "type": "bool"
+        },
+        {
+          "name": "sneaking",
+          "type": "bool"
+        }
+      ]
+    ],
+    "packet_level_chunk": [
+      "container",
+      [
+        {
+          "name": "x",
+          "type": "zigzag32"
+        },
+        {
+          "name": "z",
+          "type": "zigzag32"
+        },
+        {
+          "name": "sub_chunk_count",
+          "type": "varint"
+        },
+        {
+          "name": "cache_enabled",
+          "type": "bool"
+        },
+        {
+          "name": "blobs",
+          "type": [
+            "switch",
+            {
+              "compareTo": "cache_enabled",
+              "fields": {
+                "true": [
+                  "container",
+                  [
+                    {
+                      "name": "hashes",
+                      "type": [
+                        "array",
+                        {
+                          "countType": "varint",
+                          "type": "lu64"
+                        }
+                      ]
+                    }
+                  ]
+                ]
+              },
+              "default": "void"
+            }
+          ]
+        },
+        {
+          "name": "payload",
+          "type": "ByteArray"
+        }
+      ]
+    ],
+    "packet_set_commands_enabled": [
+      "container",
+      [
+        {
+          "name": "enabled",
+          "type": "bool"
+        }
+      ]
+    ],
+    "packet_set_difficulty": [
+      "container",
+      [
+        {
+          "name": "difficulty",
+          "type": "varint"
+        }
+      ]
+    ],
+    "packet_change_dimension": [
+      "container",
+      [
+        {
+          "name": "dimension",
+          "type": "zigzag32"
+        },
+        {
+          "name": "position",
+          "type": "vec3f"
+        },
+        {
+          "name": "respawn",
+          "type": "bool"
+        }
+      ]
+    ],
+    "packet_set_player_game_type": [
+      "container",
+      [
+        {
+          "name": "gamemode",
+          "type": "GameMode"
+        }
+      ]
+    ],
+    "packet_player_list": [
+      "container",
+      [
+        {
+          "name": "records",
+          "type": "PlayerRecords"
+        }
+      ]
+    ],
+    "packet_simple_event": [
+      "container",
+      [
+        {
+          "name": "event_type",
+          "type": "lu16"
+        }
+      ]
+    ],
+    "packet_event": [
+      "container",
+      [
+        {
+          "name": "runtime_id",
+          "type": "varint64"
+        },
+        {
+          "name": "event_type",
+          "type": [
+            "mapper",
+            {
+              "type": "zigzag32",
+              "mappings": {
+                "0": "achievement_awarded",
+                "1": "entity_interact",
+                "2": "portal_built",
+                "3": "portal_used",
+                "4": "mob_killed",
+                "5": "cauldron_used",
+                "6": "player_death",
+                "7": "boss_killed",
+                "8": "agent_command",
+                "9": "agent_created",
+                "10": "banner_pattern_removed",
+                "11": "commaned_executed",
+                "12": "fish_bucketed",
+                "13": "mob_born",
+                "14": "pet_died",
+                "15": "cauldron_block_used",
+                "16": "composter_block_used",
+                "17": "bell_block_used",
+                "18": "actor_definition",
+                "19": "raid_update",
+                "20": "player_movement_anomaly",
+                "21": "player_moement_corrected",
+                "22": "honey_harvested",
+                "23": "target_block_hit",
+                "24": "piglin_barter"
+              }
+            }
+          ]
+        },
+        {
+          "name": "use_player_id",
+          "type": "u8"
+        },
+        {
+          "name": "event_data",
+          "type": "restBuffer"
+        }
+      ]
+    ],
+    "packet_spawn_experience_orb": [
+      "container",
+      [
+        {
+          "name": "position",
+          "type": "vec3f"
+        },
+        {
+          "name": "count",
+          "type": "zigzag32"
+        }
+      ]
+    ],
+    "packet_clientbound_map_item_data": [
+      "container",
+      [
+        {
+          "name": "mapinfo",
+          "type": "MapInfo"
+        }
+      ]
+    ],
+    "packet_map_info_request": [
+      "container",
+      [
+        {
+          "name": "map_id",
+          "type": "zigzag64"
+        }
+      ]
+    ],
+    "packet_request_chunk_radius": [
+      "container",
+      [
+        {
+          "name": "chunk_radius",
+          "type": "zigzag32"
+        }
+      ]
+    ],
+    "packet_chunk_radius_update": [
+      "container",
+      [
+        {
+          "name": "chunk_radius",
+          "type": "zigzag32"
+        }
+      ]
+    ],
+    "packet_item_frame_drop_item": [
+      "container",
+      [
+        {
+          "name": "coordinates",
+          "type": "BlockCoordinates"
+        }
+      ]
+    ],
+    "packet_game_rules_changed": [
+      "container",
+      [
+        {
+          "name": "rules",
+          "type": "GameRules"
+        }
+      ]
+    ],
+    "packet_camera": [
+      "container",
+      [
+        {
+          "name": "camera_entity_unique_id",
+          "type": "zigzag64"
+        },
+        {
+          "name": "target_player_unique_id",
+          "type": "zigzag64"
+        }
+      ]
+    ],
+    "packet_boss_event": [
+      "container",
+      [
+        {
+          "name": "boss_entity_id",
+          "type": "zigzag64"
+        },
+        {
+          "name": "type",
+          "type": [
+            "mapper",
+            {
+              "type": "varint",
+              "mappings": {
+                "0": "show_bar",
+                "1": "register_player",
+                "2": "hide_bar",
+                "3": "unregister_player",
+                "4": "set_bar_progress",
+                "5": "set_bar_title",
+                "6": "update_properties",
+                "7": "texture"
+              }
+            }
+          ]
+        },
+        {
+          "anon": true,
+          "type": [
+            "switch",
+            {
+              "compareTo": "type",
+              "fields": {
+                "register_player": [
+                  "container",
+                  [
+                    {
+                      "name": "player_id",
+                      "type": "zigzag64"
+                    }
+                  ]
+                ],
+                "unregister_player": [
+                  "container",
+                  [
+                    {
+                      "name": "player_id",
+                      "type": "zigzag64"
+                    }
+                  ]
+                ],
+                "show": [
+                  "container",
+                  [
+                    {
+                      "name": "title",
+                      "type": "string"
+                    },
+                    {
+                      "name": "bar_progress",
+                      "type": "lf32"
+                    }
+                  ]
+                ],
+                "update_properties": [
+                  "container",
+                  [
+                    {
+                      "name": "darkness_factor",
+                      "type": "li16"
+                    }
+                  ]
+                ],
+                "texture": [
+                  "container",
+                  [
+                    {
+                      "name": "color",
+                      "type": "varint"
+                    },
+                    {
+                      "name": "overlay",
+                      "type": "varint"
+                    }
+                  ]
+                ],
+                "set_bar_progress": [
+                  "container",
+                  [
+                    {
+                      "name": "bar_progress",
+                      "type": "lf32"
+                    }
+                  ]
+                ],
+                "set_bar_title": [
+                  "container",
+                  [
+                    {
+                      "name": "title",
+                      "type": "string"
+                    }
+                  ]
+                ]
+              },
+              "default": "void"
+            }
+          ]
+        }
+      ]
+    ],
+    "packet_show_credits": [
+      "container",
+      [
+        {
+          "name": "runtime_entity_id",
+          "type": "varint"
+        },
+        {
+          "name": "status",
+          "type": "zigzag32"
+        }
+      ]
+    ],
+    "packet_available_commands": [
+      "container",
+      [
+        {
+          "name": "values_len",
+          "type": "varint"
+        },
+        {
+          "name": "_enum_type",
+          "type": [
+            "enum_size_based_on_values_len"
+          ]
+        },
+        {
+          "name": "enum_values",
+          "type": [
+            "array",
+            {
+              "count": "values_len",
+              "type": "string"
+            }
+          ]
+        },
+        {
+          "name": "suffixes",
+          "type": [
+            "array",
+            {
+              "countType": "varint",
+              "type": "string"
+            }
+          ]
+        },
+        {
+          "name": "enums",
+          "type": [
+            "array",
+            {
+              "countType": "varint",
+              "type": [
+                "container",
+                [
+                  {
+                    "name": "name",
+                    "type": "string"
+                  },
+                  {
+                    "name": "values",
+                    "type": [
+                      "array",
+                      {
+                        "countType": "varint",
+                        "type": [
+                          "switch",
+                          {
+                            "compareTo": "../_enum_type",
+                            "fields": {
+                              "byte": "u8",
+                              "short": "lu16",
+                              "int": "lu32"
+                            },
+                            "default": "void"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              ]
+            }
+          ]
+        },
+        {
+          "name": "command_data",
+          "type": [
+            "array",
+            {
+              "countType": "varint",
+              "type": [
+                "container",
+                [
+                  {
+                    "name": "name",
+                    "type": "string"
+                  },
+                  {
+                    "name": "description",
+                    "type": "string"
+                  },
+                  {
+                    "name": "flags",
+                    "type": "u8"
+                  },
+                  {
+                    "name": "permission_level",
+                    "type": "u8"
+                  },
+                  {
+                    "name": "alias",
+                    "type": "li32"
+                  },
+                  {
+                    "name": "overloads",
+                    "type": [
+                      "array",
+                      {
+                        "countType": "varint",
+                        "type": [
+                          "array",
+                          {
+                            "countType": "varint",
+                            "type": [
+                              "container",
+                              [
+                                {
+                                  "name": "paramater_name",
+                                  "type": "string"
+                                },
+                                {
+                                  "name": "value_type",
+                                  "type": [
+                                    "mapper",
+                                    {
+                                      "type": "lu16",
+                                      "mappings": {
+                                        "1": "int",
+                                        "2": "float",
+                                        "3": "value",
+                                        "4": "wildcard_int",
+                                        "5": "operator",
+                                        "6": "target",
+                                        "16": "file_path",
+                                        "32": "string",
+                                        "40": "position",
+                                        "44": "message",
+                                        "46": "raw_text",
+                                        "50": "json",
+                                        "63": "command"
+                                      }
+                                    }
+                                  ]
+                                },
+                                {
+                                  "name": "enum_type",
+                                  "type": [
+                                    "mapper",
+                                    {
+                                      "type": "lu16",
+                                      "mappings": {
+                                        "16": "valid",
+                                        "32": "enum",
+                                        "256": "suffixed",
+                                        "1024": "soft_enum"
+                                      }
+                                    }
+                                  ]
+                                },
+                                {
+                                  "name": "optional",
+                                  "type": "bool"
+                                },
+                                {
+                                  "name": "options",
+                                  "type": "CommandFlags"
+                                }
+                              ]
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              ]
+            }
+          ]
+        },
+        {
+          "name": "dynamic_enums",
+          "type": [
+            "array",
+            {
+              "countType": "varint",
+              "type": [
+                "container",
+                [
+                  {
+                    "name": "name",
+                    "type": "string"
+                  },
+                  {
+                    "name": "values",
+                    "type": [
+                      "array",
+                      {
+                        "countType": "varint",
+                        "type": "string"
+                      }
+                    ]
+                  }
+                ]
+              ]
+            }
+          ]
+        },
+        {
+          "name": "enum_constraints",
+          "type": [
+            "array",
+            {
+              "countType": "varint",
+              "type": [
+                "container",
+                [
+                  {
+                    "name": "value_index",
+                    "type": "li32"
+                  },
+                  {
+                    "name": "enum_index",
+                    "type": "li32"
+                  },
+                  {
+                    "name": "constraints",
+                    "type": [
+                      "array",
+                      {
+                        "countType": "varint",
+                        "type": [
+                          "container",
+                          [
+                            {
+                              "name": "constraint",
+                              "type": [
+                                "mapper",
+                                {
+                                  "type": "u8",
+                                  "mappings": {
+                                    "0": "cheats_enabled"
+                                  }
+                                }
+                              ]
+                            }
+                          ]
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              ]
+            }
+          ]
+        }
+      ]
+    ],
+    "packet_command_request": [
+      "container",
+      [
+        {
+          "name": "command",
+          "type": "string"
+        },
+        {
+          "name": "origin",
+          "type": "CommandOrigin"
+        },
+        {
+          "name": "interval",
+          "type": "bool"
+        }
+      ]
+    ],
+    "packet_command_block_update": [
+      "container",
+      [
+        {
+          "name": "is_block",
+          "type": "bool"
+        }
+      ]
+    ],
+    "packet_command_output": [
+      "container",
+      [
+        {
+          "name": "origin",
+          "type": "CommandOrigin"
+        },
+        {
+          "name": "output_type",
+          "type": [
+            "mapper",
+            {
+              "type": "i8",
+              "mappings": {
+                "1": "last",
+                "2": "silent",
+                "3": "all",
+                "4": "data_set"
+              }
+            }
+          ]
+        },
+        {
+          "name": "success_count",
+          "type": "varint"
+        },
+        {
+          "name": "output",
+          "type": [
+            "array",
+            {
+              "countType": "varint",
+              "type": [
+                "container",
+                [
+                  {
+                    "name": "success",
+                    "type": "bool"
+                  },
+                  {
+                    "name": "message_id",
+                    "type": "string"
+                  },
+                  {
+                    "name": "paramaters",
+                    "type": [
+                      "array",
+                      {
+                        "countType": "varint",
+                        "type": "string"
+                      }
+                    ]
+                  }
+                ]
+              ]
+            }
+          ]
+        },
+        {
+          "name": "data_set",
+          "type": [
+            "switch",
+            {
+              "compareTo": "output_type",
+              "fields": {
+                "data_set": "string"
+              },
+              "default": "void"
+            }
+          ]
+        }
+      ]
+    ],
+    "packet_update_trade": [
+      "container",
+      [
+        {
+          "name": "window_id",
+          "type": "u8"
+        },
+        {
+          "name": "window_type",
+          "type": "WindowType"
+        },
+        {
+          "name": "size",
+          "type": "varint"
+        },
+        {
+          "name": "trade_tier",
+          "type": "varint"
+        },
+        {
+          "name": "villager_unique_id",
+          "type": "varint64"
+        },
+        {
+          "name": "entity_unique_id",
+          "type": "varint64"
+        },
+        {
+          "name": "display_name",
+          "type": "string"
+        },
+        {
+          "name": "new_trading_ui",
+          "type": "bool"
+        },
+        {
+          "name": "economic_trades",
+          "type": "bool"
+        },
+        {
+          "name": "offers",
+          "type": "nbt"
+        }
+      ]
+    ],
+    "packet_update_equipment": [
+      "container",
+      [
+        {
+          "name": "window_id",
+          "type": "u8"
+        },
+        {
+          "name": "window_type",
+          "type": "WindowType"
+        },
+        {
+          "name": "size",
+          "type": "u8"
+        },
+        {
+          "name": "entity_id",
+          "type": "zigzag64"
+        },
+        {
+          "name": "inventory",
+          "type": "nbt"
+        }
+      ]
+    ],
+    "packet_resource_pack_data_info": [
+      "container",
+      [
+        {
+          "name": "package_id",
+          "type": "string"
+        },
+        {
+          "name": "max_chunk_size",
+          "type": "lu32"
+        },
+        {
+          "name": "chunk_count",
+          "type": "lu32"
+        },
+        {
+          "name": "compressed_package_size",
+          "type": "lu64"
+        },
+        {
+          "name": "hash",
+          "type": "ByteArray"
+        },
+        {
+          "name": "is_premium",
+          "type": "bool"
+        },
+        {
+          "name": "pack_type",
+          "type": "u8"
+        }
+      ]
+    ],
+    "packet_resource_pack_chunk_data": [
+      "container",
+      [
+        {
+          "name": "package_id",
+          "type": "string"
+        },
+        {
+          "name": "chunk_index",
+          "type": "lu32"
+        },
+        {
+          "name": "progress",
+          "type": "lu64"
+        },
+        {
+          "name": "payload",
+          "type": "ByteArray"
+        }
+      ]
+    ],
+    "packet_resource_pack_chunk_request": [
+      "container",
+      [
+        {
+          "name": "package_id",
+          "type": "string"
+        },
+        {
+          "name": "chunk_index",
+          "type": "lu32"
+        }
+      ]
+    ],
+    "packet_transfer": [
+      "container",
+      [
+        {
+          "name": "server_address",
+          "type": "string"
+        },
+        {
+          "name": "port",
+          "type": "lu16"
+        }
+      ]
+    ],
+    "packet_play_sound": [
+      "container",
+      [
+        {
+          "name": "name",
+          "type": "string"
+        },
+        {
+          "name": "coordinates",
+          "type": "BlockCoordinates"
+        },
+        {
+          "name": "volume",
+          "type": "lf32"
+        },
+        {
+          "name": "pitch",
+          "type": "lf32"
+        }
+      ]
+    ],
+    "packet_stop_sound": [
+      "container",
+      [
+        {
+          "name": "name",
+          "type": "string"
+        },
+        {
+          "name": "stop_all",
+          "type": "bool"
+        }
+      ]
+    ],
+    "packet_set_title": [
+      "container",
+      [
+        {
+          "name": "type",
+          "type": [
+            "mapper",
+            {
+              "type": "zigzag32",
+              "mappings": {
+                "0": "clear",
+                "1": "reset",
+                "2": "set_title",
+                "3": "set_subtitle",
+                "4": "action_bar_message",
+                "5": "set_durations",
+                "6": "set_title_json",
+                "7": "set_subtitle_json",
+                "8": "action_bar_message_json"
+              }
+            }
+          ]
+        },
+        {
+          "name": "text",
+          "type": "string"
+        },
+        {
+          "name": "fade_in_time",
+          "type": "zigzag32"
+        },
+        {
+          "name": "stay_time",
+          "type": "zigzag32"
+        },
+        {
+          "name": "fade_out_time",
+          "type": "zigzag32"
+        }
+      ]
+    ],
+    "packet_add_behavior_tree": [
+      "container",
+      [
+        {
+          "name": "behaviortree",
+          "type": "string"
+        }
+      ]
+    ],
+    "packet_structure_block_update": [
+      "container",
+      []
+    ],
+    "packet_show_store_offer": [
+      "container",
+      [
+        {
+          "name": "unknown0",
+          "type": "string"
+        },
+        {
+          "name": "unknown1",
+          "type": "bool"
+        }
+      ]
+    ],
+    "packet_purchase_receipt": [
+      "container",
+      []
+    ],
+    "packet_player_skin": [
+      "container",
+      [
+        {
+          "name": "uuid",
+          "type": "uuid"
+        },
+        {
+          "name": "skin",
+          "type": "Skin"
+        },
+        {
+          "name": "skin_name",
+          "type": "string"
+        },
+        {
+          "name": "old_skin_name",
+          "type": "string"
+        },
+        {
+          "name": "is_verified",
+          "type": "bool"
+        }
+      ]
+    ],
+    "packet_sub_client_login": [
+      "container",
+      []
+    ],
+    "packet_initiate_web_socket_connection": [
+      "container",
+      [
+        {
+          "name": "server",
+          "type": "string"
+        }
+      ]
+    ],
+    "packet_set_last_hurt_by": [
+      "container",
+      [
+        {
+          "name": "unknown",
+          "type": "varint"
+        }
+      ]
+    ],
+    "packet_book_edit": [
+      "container",
+      [
+        {
+          "name": "type",
+          "type": [
+            "mapper",
+            {
+              "type": "u8",
+              "mappings": {
+                "0": "replace_page",
+                "1": "add_page",
+                "2": "delete_page",
+                "3": "swap_pages",
+                "4": "sign"
+              }
+            }
+          ]
+        },
+        {
+          "name": "slot",
+          "type": "u8"
+        },
+        {
+          "anon": true,
+          "type": [
+            "switch",
+            {
+              "compareTo": "type",
+              "fields": {
+                "replace_page": [
+                  "container",
+                  [
+                    {
+                      "name": "page_number",
+                      "type": "u8"
+                    },
+                    {
+                      "name": "text",
+                      "type": "string"
+                    },
+                    {
+                      "name": "photo_name",
+                      "type": "string"
+                    }
+                  ]
+                ],
+                "add_page": [
+                  "container",
+                  [
+                    {
+                      "name": "page_number",
+                      "type": "u8"
+                    },
+                    {
+                      "name": "text",
+                      "type": "string"
+                    },
+                    {
+                      "name": "photo_name",
+                      "type": "string"
+                    }
+                  ]
+                ],
+                "delete_page": [
+                  "container",
+                  [
+                    {
+                      "name": "page_number",
+                      "type": "u8"
+                    }
+                  ]
+                ],
+                "swap_pages": [
+                  "container",
+                  [
+                    {
+                      "name": "page1",
+                      "type": "u8"
+                    },
+                    {
+                      "name": "page2",
+                      "type": "u8"
+                    }
+                  ]
+                ],
+                "sign": [
+                  "container",
+                  [
+                    {
+                      "name": "title",
+                      "type": "string"
+                    },
+                    {
+                      "name": "author",
+                      "type": "string"
+                    },
+                    {
+                      "name": "xuid",
+                      "type": "string"
+                    }
+                  ]
+                ]
+              },
+              "default": "void"
+            }
+          ]
+        }
+      ]
+    ],
+    "packet_npc_request": [
+      "container",
+      [
+        {
+          "name": "runtime_entity_id",
+          "type": "varint"
+        },
+        {
+          "name": "unknown0",
+          "type": "u8"
+        },
+        {
+          "name": "unknown1",
+          "type": "string"
+        },
+        {
+          "name": "unknown2",
+          "type": "u8"
+        }
+      ]
+    ],
+    "packet_photo_transfer": [
+      "container",
+      [
+        {
+          "name": "file_name",
+          "type": "string"
+        },
+        {
+          "name": "image_data",
+          "type": "string"
+        },
+        {
+          "name": "unknown2",
+          "type": "string"
+        }
+      ]
+    ],
+    "packet_modal_form_request": [
+      "container",
+      [
+        {
+          "name": "form_id",
+          "type": "varint"
+        },
+        {
+          "name": "data",
+          "type": "string"
+        }
+      ]
+    ],
+    "packet_modal_form_response": [
+      "container",
+      [
+        {
+          "name": "form_id",
+          "type": "varint"
+        },
+        {
+          "name": "data",
+          "type": "string"
+        }
+      ]
+    ],
+    "packet_server_settings_request": [
+      "container",
+      []
+    ],
+    "packet_server_settings_response": [
+      "container",
+      [
+        {
+          "name": "form_id",
+          "type": "varint"
+        },
+        {
+          "name": "data",
+          "type": "string"
+        }
+      ]
+    ],
+    "packet_show_profile": [
+      "container",
+      [
+        {
+          "name": "xuid",
+          "type": "string"
+        }
+      ]
+    ],
+    "packet_set_default_game_type": [
+      "container",
+      [
+        {
+          "name": "gamemode",
+          "type": "GameMode"
+        }
+      ]
+    ],
+    "packet_remove_objective": [
+      "container",
+      [
+        {
+          "name": "objective_name",
+          "type": "string"
+        }
+      ]
+    ],
+    "packet_set_display_objective": [
+      "container",
+      [
+        {
+          "name": "display_slot",
+          "type": "string"
+        },
+        {
+          "name": "objective_name",
+          "type": "string"
+        },
+        {
+          "name": "display_name",
+          "type": "string"
+        },
+        {
+          "name": "criteria_name",
+          "type": "string"
+        },
+        {
+          "name": "sort_order",
+          "type": "zigzag32"
+        }
+      ]
+    ],
+    "packet_set_score": [
+      "container",
+      [
+        {
+          "name": "entries",
+          "type": "ScoreEntries"
+        }
+      ]
+    ],
+    "packet_lab_table": [
+      "container",
+      [
+        {
+          "name": "useless_byte",
+          "type": "u8"
+        },
+        {
+          "name": "lab_table_x",
+          "type": "varint"
+        },
+        {
+          "name": "lab_table_y",
+          "type": "varint"
+        },
+        {
+          "name": "lab_table_z",
+          "type": "varint"
+        },
+        {
+          "name": "reaction_type",
+          "type": "u8"
+        }
+      ]
+    ],
+    "packet_update_block_synced": [
+      "container",
+      [
+        {
+          "name": "position",
+          "type": "BlockCoordinates"
+        },
+        {
+          "name": "block_runtime_id",
+          "type": "varint"
+        },
+        {
+          "name": "flags",
+          "type": "UpdateBlockFlags"
+        },
+        {
+          "name": "layer",
+          "type": "varint"
+        },
+        {
+          "name": "entity_unique_id",
+          "type": "varint"
+        },
+        {
+          "name": "transition_type",
+          "type": [
+            "mapper",
+            {
+              "type": "varint",
+              "mappings": {
+                "0": "entity",
+                "1": "create",
+                "2": "destroy"
+              }
+            }
+          ]
+        }
+      ]
+    ],
+    "packet_move_entity_delta": [
+      "container",
+      [
+        {
+          "name": "runtime_entity_id",
+          "type": "varint64"
+        },
+        {
+          "name": "flags",
+          "type": "DeltaMoveFlags"
+        },
+        {
+          "name": "x",
+          "type": [
+            "switch",
+            {
+              "compareTo": "flags.has_x",
+              "fields": {
+                "true": "lf32"
+              },
+              "default": "void"
+            }
+          ]
+        },
+        {
+          "name": "y",
+          "type": [
+            "switch",
+            {
+              "compareTo": "flags.has_y",
+              "fields": {
+                "true": "lf32"
+              },
+              "default": "void"
+            }
+          ]
+        },
+        {
+          "name": "z",
+          "type": [
+            "switch",
+            {
+              "compareTo": "flags.has_z",
+              "fields": {
+                "true": "lf32"
+              },
+              "default": "void"
+            }
+          ]
+        },
+        {
+          "name": "rot_x",
+          "type": [
+            "switch",
+            {
+              "compareTo": "flags.has_rot_x",
+              "fields": {
+                "true": "u8"
+              },
+              "default": "void"
+            }
+          ]
+        },
+        {
+          "name": "rot_y",
+          "type": [
+            "switch",
+            {
+              "compareTo": "flags.has_rot_y",
+              "fields": {
+                "true": "u8"
+              },
+              "default": "void"
+            }
+          ]
+        },
+        {
+          "name": "rot_z",
+          "type": [
+            "switch",
+            {
+              "compareTo": "flags.has_rot_z",
+              "fields": {
+                "true": "u8"
+              },
+              "default": "void"
+            }
+          ]
+        }
+      ]
+    ],
+    "packet_set_scoreboard_identity": [
+      "container",
+      [
+        {
+          "name": "entries",
+          "type": "ScoreboardIdentityEntries"
+        }
+      ]
+    ],
+    "packet_set_local_player_as_initialized": [
+      "container",
+      [
+        {
+          "name": "runtime_entity_id",
+          "type": "varint64"
+        }
+      ]
+    ],
+    "packet_update_soft_enum": [
+      "container",
+      []
+    ],
+    "packet_network_stack_latency": [
+      "container",
+      [
+        {
+          "name": "timestamp",
+          "type": "lu64"
+        },
+        {
+          "name": "unknown_flag",
+          "type": "u8"
+        }
+      ]
+    ],
+    "packet_script_custom_event": [
+      "container",
+      [
+        {
+          "name": "event_name",
+          "type": "string"
+        },
+        {
+          "name": "event_data",
+          "type": "string"
+        }
+      ]
+    ],
+    "packet_spawn_particle_effect": [
+      "container",
+      [
+        {
+          "name": "dimension_id",
+          "type": "u8"
+        },
+        {
+          "name": "entity_id",
+          "type": "zigzag64"
+        },
+        {
+          "name": "position",
+          "type": "vec3f"
+        },
+        {
+          "name": "particle_name",
+          "type": "string"
+        }
+      ]
+    ],
+    "packet_available_entity_identifiers": [
+      "container",
+      [
+        {
+          "name": "nbt",
+          "type": "nbt"
+        }
+      ]
+    ],
+    "packet_level_sound_event_v2": [
+      "container",
+      [
+        {
+          "name": "sound_id",
+          "type": "u8"
+        },
+        {
+          "name": "position",
+          "type": "vec3f"
+        },
+        {
+          "name": "block_id",
+          "type": "zigzag32"
+        },
+        {
+          "name": "entity_type",
+          "type": "string"
+        },
+        {
+          "name": "is_baby_mob",
+          "type": "bool"
+        },
+        {
+          "name": "is_global",
+          "type": "bool"
+        }
+      ]
+    ],
+    "packet_network_chunk_publisher_update": [
+      "container",
+      [
+        {
+          "name": "coordinates",
+          "type": "BlockCoordinates"
+        },
+        {
+          "name": "radius",
+          "type": "varint"
+        }
+      ]
+    ],
+    "packet_biome_definition_list": [
+      "container",
+      [
+        {
+          "name": "nbt",
+          "type": "nbt"
+        }
+      ]
+    ],
+    "packet_level_sound_event": [
+      "container",
+      [
+        {
+          "name": "sound_id",
+          "type": "varint"
+        },
+        {
+          "name": "position",
+          "type": "vec3f"
+        },
+        {
+          "name": "block_id",
+          "type": "zigzag32"
+        },
+        {
+          "name": "entity_type",
+          "type": "string"
+        },
+        {
+          "name": "is_baby_mob",
+          "type": "bool"
+        },
+        {
+          "name": "is_global",
+          "type": "bool"
+        }
+      ]
+    ],
+    "packet_level_event_generic": [
+      "container",
+      [
+        {
+          "name": "event_id",
+          "type": "varint"
+        },
+        {
+          "name": "nbt",
+          "type": "nbtLoop"
+        }
+      ]
+    ],
+    "packet_lectern_update": [
+      "container",
+      [
+        {
+          "name": "page",
+          "type": "u8"
+        },
+        {
+          "name": "page_count",
+          "type": "u8"
+        },
+        {
+          "name": "position",
+          "type": "vec3i"
+        },
+        {
+          "name": "drop_book",
+          "type": "bool"
+        }
+      ]
+    ],
+    "packet_video_stream_connect": [
+      "container",
+      [
+        {
+          "name": "server_uri",
+          "type": "string"
+        },
+        {
+          "name": "frame_send_frequency",
+          "type": "lf32"
+        },
+        {
+          "name": "action",
+          "type": "u8"
+        },
+        {
+          "name": "resolution_x",
+          "type": "li32"
+        },
+        {
+          "name": "resolution_y",
+          "type": "li32"
+        }
+      ]
+    ],
+    "packet_add_ecs_entity": [
+      "container",
+      [
+        {
+          "name": "network_id",
+          "type": "varint64"
+        }
+      ]
+    ],
+    "packet_remove_ecs_entity": [
+      "container",
+      [
+        {
+          "name": "network_id",
+          "type": "varint64"
+        }
+      ]
+    ],
+    "packet_client_cache_status": [
+      "container",
+      [
+        {
+          "name": "enabled",
+          "type": "bool"
+        }
+      ]
+    ],
+    "packet_on_screen_texture_animation": [
+      "container",
+      []
+    ],
+    "packet_map_create_locked_copy": [
+      "container",
+      []
+    ],
+    "packet_structure_template_data_export_request": [
+      "container",
+      []
+    ],
+    "packet_structure_template_data_export_response": [
+      "container",
+      []
+    ],
+    "packet_update_block_properties": [
+      "container",
+      [
+        {
+          "name": "nbt",
+          "type": "nbt"
+        }
+      ]
+    ],
+    "packet_client_cache_blob_status": [
+      "container",
+      [
+        {
+          "name": "misses",
+          "type": "varint"
+        },
+        {
+          "name": "haves",
+          "type": "varint"
+        },
+        {
+          "name": "missing",
+          "type": [
+            "array",
+            {
+              "count": "misses",
+              "type": "lu64"
+            }
+          ]
+        },
+        {
+          "name": "have",
+          "type": [
+            "array",
+            {
+              "count": "haves",
+              "type": "lu64"
+            }
+          ]
+        }
+      ]
+    ],
+    "packet_client_cache_miss_response": [
+      "container",
+      [
+        {
+          "name": "blobs",
+          "type": [
+            "array",
+            {
+              "countType": "varint",
+              "type": "Blob"
+            }
+          ]
+        }
+      ]
+    ],
+    "packet_education_settings": [
+      "container",
+      [
+        {
+          "name": "CodeBuilderDefaultURI",
+          "type": "string"
+        },
+        {
+          "name": "CodeBuilderTitle",
+          "type": "string"
+        },
+        {
+          "name": "CanResizeCodeBuilder",
+          "type": "bool"
+        },
+        {
+          "name": "HasOverrideURI",
+          "type": "bool"
+        },
+        {
+          "name": "OverrideURI",
+          "type": [
+            "switch",
+            {
+              "compareTo": "HasOverrideURI",
+              "fields": {
+                "true": "string"
+              },
+              "default": "void"
+            }
+          ]
+        },
+        {
+          "name": "HasQuiz",
+          "type": "bool"
+        }
+      ]
+    ],
+    "packet_multiplayer_settings": [
+      "container",
+      [
+        {
+          "name": "action_type",
+          "type": [
+            "mapper",
+            {
+              "type": "zigzag32",
+              "mappings": {
+                "0": "enable_multiplayer",
+                "1": "disable_multiplayer",
+                "2": "refresh_join_code"
+              }
+            }
+          ]
+        }
+      ]
+    ],
+    "packet_settings_command": [
+      "container",
+      [
+        {
+          "name": "command_line",
+          "type": "string"
+        },
+        {
+          "name": "suppress_output",
+          "type": "bool"
+        }
+      ]
+    ],
+    "packet_anvil_damage": [
+      "container",
+      [
+        {
+          "name": "damage",
+          "type": "u8"
+        },
+        {
+          "name": "position",
+          "type": "BlockCoordinates"
+        }
+      ]
+    ],
+    "packet_completed_using_item": [
+      "container",
+      [
+        {
+          "name": "used_item_id",
+          "type": "li16"
+        },
+        {
+          "name": "use_method",
+          "type": [
+            "mapper",
+            {
+              "type": "li32",
+              "mappings": {
+                "0": "equip_armor",
+                "1": "eat",
+                "2": "attack",
+                "3": "consume",
+                "4": "throw",
+                "5": "shoot",
+                "6": "place",
+                "7": "fill_bottle",
+                "8": "fill_bucket",
+                "9": "pour_bucket",
+                "10": "use_tool",
+                "11": "interact",
+                "12": "retrieved",
+                "13": "dyed",
+                "14": "traded"
+              }
+            }
+          ]
+        }
+      ]
+    ],
+    "packet_network_settings": [
+      "container",
+      [
+        {
+          "name": "compression_threshold",
+          "type": "u16"
+        }
+      ]
+    ],
+    "packet_player_auth_input": [
+      "container",
+      [
+        {
+          "name": "pitch",
+          "type": "lf32"
+        },
+        {
+          "name": "yaw",
+          "type": "lf32"
+        },
+        {
+          "name": "position",
+          "type": "vec3f"
+        },
+        {
+          "name": "move_vector",
+          "type": "vec2f"
+        },
+        {
+          "name": "head_yaw",
+          "type": "lf32"
+        },
+        {
+          "name": "input_data",
+          "type": "InputFlag"
+        },
+        {
+          "name": "input_mode",
+          "type": [
+            "mapper",
+            {
+              "type": "varint",
+              "mappings": {
+                "0": "mouse",
+                "1": "touch",
+                "2": "game_pad",
+                "3": "motion_controller"
+              }
+            }
+          ]
+        },
+        {
+          "name": "play_mode",
+          "type": [
+            "mapper",
+            {
+              "type": "varint",
+              "mappings": {
+                "0": "normal",
+                "1": "teaser",
+                "2": "screen",
+                "3": "viewer",
+                "4": "reality",
+                "5": "placement",
+                "6": "living_room",
+                "7": "exit_level",
+                "8": "exit_level_living_room",
+                "9": "num_modes"
+              }
+            }
+          ]
+        },
+        {
+          "name": "gaze_direction",
+          "type": [
+            "switch",
+            {
+              "compareTo": "play_mode",
+              "fields": {
+                "reality": "vec3f"
+              },
+              "default": "void"
+            }
+          ]
+        },
+        {
+          "name": "tick",
+          "type": "varint64"
+        },
+        {
+          "name": "delta",
+          "type": "vec3f"
+        }
+      ]
+    ],
+    "packet_creative_content": [
+      "container",
+      [
+        {
+          "name": "items",
+          "type": "ItemStacks"
+        }
+      ]
+    ],
+    "packet_player_enchant_options": [
+      "container",
+      [
+        {
+          "name": "enchant_options",
+          "type": "EnchantOptions"
+        }
+      ]
+    ],
+    "packet_item_stack_request": [
+      "container",
+      [
+        {
+          "name": "requests",
+          "type": "ItemStackRequests"
+        }
+      ]
+    ],
+    "packet_item_stack_response": [
+      "container",
+      [
+        {
+          "name": "responses",
+          "type": "ItemStackResponses"
+        }
+      ]
+    ],
+    "packet_player_armor_damage": [
+      "container",
+      [
+        {
+          "name": "type",
+          "type": "ArmorDamageType"
+        },
+        {
+          "name": "helmet_damage",
+          "type": [
+            "switch",
+            {
+              "compareTo": "type.head",
+              "fields": {
+                "true": "zigzag32"
+              },
+              "default": "void"
+            }
+          ]
+        },
+        {
+          "name": "chestplate_damage",
+          "type": [
+            "switch",
+            {
+              "compareTo": "type.chest",
+              "fields": {
+                "true": "zigzag32"
+              },
+              "default": "void"
+            }
+          ]
+        },
+        {
+          "name": "leggings_damage",
+          "type": [
+            "switch",
+            {
+              "compareTo": "type.legs",
+              "fields": {
+                "true": "zigzag32"
+              },
+              "default": "void"
+            }
+          ]
+        },
+        {
+          "name": "boots_damage",
+          "type": [
+            "switch",
+            {
+              "compareTo": "types.feet",
+              "fields": {
+                "true": "zigzag32"
+              },
+              "default": "void"
+            }
+          ]
+        }
+      ]
+    ],
+    "packet_update_player_game_type": [
+      "container",
+      [
+        {
+          "name": "gamemode",
+          "type": "GameMode"
+        },
+        {
+          "name": "player_unique_id",
+          "type": "zigzag64"
+        }
+      ]
+    ],
+    "packet_position_tracking_db_request": [
+      "container",
+      [
+        {
+          "name": "action",
+          "type": [
+            "mapper",
+            {
+              "type": "u8",
+              "mappings": {
+                "0": "query"
+              }
+            }
+          ]
+        },
+        {
+          "name": "tracking_id",
+          "type": "zigzag32"
+        }
+      ]
+    ],
+    "packet_position_tracking_db_broadcast": [
+      "container",
+      [
+        {
+          "name": "broadcast_action",
+          "type": [
+            "mapper",
+            {
+              "type": "u8",
+              "mappings": {
+                "0": "update",
+                "1": "destory",
+                "2": "not_found"
+              }
+            }
+          ]
+        },
+        {
+          "name": "tracking_id",
+          "type": "zigzag32"
+        },
+        {
+          "name": "nbt",
+          "type": "nbt"
+        }
+      ]
+    ],
+    "packet_packet_violation_warning": [
+      "container",
+      [
+        {
+          "name": "violation_type",
+          "type": [
+            "mapper",
+            {
+              "type": "zigzag32",
+              "mappings": {
+                "0": "malformed"
+              }
+            }
+          ]
+        },
+        {
+          "name": "severity",
+          "type": [
+            "mapper",
+            {
+              "type": "zigzag32",
+              "mappings": {
+                "0": "warning",
+                "1": "final_warning",
+                "2": "terminating"
+              }
+            }
+          ]
+        },
+        {
+          "name": "packet_id",
+          "type": "zigzag32"
+        },
+        {
+          "name": "reason",
+          "type": "string"
+        }
+      ]
+    ],
+    "packet_motion_prediction_hints": [
+      "container",
+      [
+        {
+          "name": "entity_runtime_id",
+          "type": "varint64"
+        },
+        {
+          "name": "velocity",
+          "type": "vec3f"
+        },
+        {
+          "name": "on_ground",
+          "type": "bool"
+        }
+      ]
+    ],
+    "packet_animate_entity": [
+      "container",
+      [
+        {
+          "name": "animation",
+          "type": "string"
+        },
+        {
+          "name": "next_state",
+          "type": "string"
+        },
+        {
+          "name": "stop_condition",
+          "type": "string"
+        },
+        {
+          "name": "controller",
+          "type": "string"
+        },
+        {
+          "name": "blend_out_time",
+          "type": "lf32"
+        },
+        {
+          "name": "runtime_entity_ids",
+          "type": [
+            "array",
+            {
+              "countType": "varint",
+              "type": "varint64"
+            }
+          ]
+        }
+      ]
+    ],
+    "packet_camera_shake": [
+      "container",
+      [
+        {
+          "name": "intensity",
+          "type": "lf32"
+        },
+        {
+          "name": "duration",
+          "type": "lf32"
+        },
+        {
+          "name": "type",
+          "type": "u8"
+        },
+        {
+          "name": "action",
+          "type": [
+            "mapper",
+            {
+              "type": "u8",
+              "mappings": {
+                "0": "add",
+                "1": "stop"
+              }
+            }
+          ]
+        }
+      ]
+    ],
+    "packet_player_fog": [
+      "container",
+      [
+        {
+          "name": "stack",
+          "type": [
+            "array",
+            {
+              "countType": "varint",
+              "type": "string"
+            }
+          ]
+        }
+      ]
+    ],
+    "packet_correct_player_move_prediction": [
+      "container",
+      [
+        {
+          "name": "position",
+          "type": "vec3f"
+        },
+        {
+          "name": "delta",
+          "type": "vec3f"
+        },
+        {
+          "name": "on_ground",
+          "type": "bool"
+        },
+        {
+          "name": "tick",
+          "type": "varint64"
+        }
+      ]
+    ],
+    "packet_item_component": [
+      "container",
+      [
+        {
+          "name": "entries",
+          "type": "ItemComponentList"
+        }
+      ]
+    ],
+    "packet_filter_text_packet": [
+      "container",
+      [
+        {
+          "name": "text",
+          "type": "string"
+        },
+        {
+          "name": "from_server",
+          "type": "bool"
+        }
+      ]
+    ],
+    "packet_debug_renderer": [
+      "container",
+      [
+        {
+          "name": "type",
+          "type": [
+            "mapper",
+            {
+              "type": "li32",
+              "mappings": {
+                "1": "clear",
+                "2": "add_cube"
+              }
+            }
+          ]
+        },
+        {
+          "anon": true,
+          "type": [
+            "switch",
+            {
+              "compareTo": "type",
+              "fields": {
+                "clear": "void",
+                "add_cube": [
+                  "container",
+                  [
+                    {
+                      "name": "text",
+                      "type": "string"
+                    },
+                    {
+                      "name": "position",
+                      "type": "vec3f"
+                    },
+                    {
+                      "name": "red",
+                      "type": "lf32"
+                    },
+                    {
+                      "name": "green",
+                      "type": "lf32"
+                    },
+                    {
+                      "name": "blue",
+                      "type": "lf32"
+                    },
+                    {
+                      "name": "alpha",
+                      "type": "lf32"
+                    },
+                    {
+                      "name": "duration",
+                      "type": "li64"
+                    }
+                  ]
+                ]
+              },
+              "default": "void"
+            }
+          ]
+        }
+      ]
+    ],
+    "string": [
+      "pstring",
+      {
+        "countType": "varint"
+      }
+    ],
+    "ByteArray": [
+      "buffer",
+      {
+        "countType": "varint"
+      }
+    ],
+    "SignedByteArray": [
+      "buffer",
+      {
+        "countType": "zigzag32"
+      }
+    ],
+    "LittleString": [
+      "pstring",
+      {
+        "countType": "li32"
+      }
+    ],
+    "MetadataFlags1": [
+      "bitflags",
+      {
+        "type": "zigzag64",
+        "big": true,
+        "shift": true,
+        "flags": {
+          "onfire": 0,
+          "sneaking": 1,
+          "riding": 2,
+          "sprinting": 3,
+          "action": 4,
+          "invisible": 5,
+          "tempted": 6,
+          "inlove": 7,
+          "saddled": 8,
+          "powered": 9,
+          "ignited": 10,
+          "baby": 11,
+          "converting": 12,
+          "critical": 13,
+          "can_show_nametag": 14,
+          "always_show_nametag": 15,
+          "no_ai": 16,
+          "silent": 17,
+          "wallclimbing": 18,
+          "can_climb": 19,
+          "swimmer": 20,
+          "can_fly": 21,
+          "walker": 22,
+          "resting": 23,
+          "sitting": 24,
+          "angry": 25,
+          "interested": 26,
+          "charged": 27,
+          "tamed": 28,
+          "orphaned": 29,
+          "leashed": 30,
+          "sheared": 31,
+          "gliding": 32,
+          "elder": 33,
+          "moving": 34,
+          "breathing": 35,
+          "chested": 36,
+          "stackable": 37,
+          "showbase": 38,
+          "rearing": 39,
+          "vibrating": 40,
+          "idling": 41,
+          "evoker_spell": 42,
+          "charge_attack": 43,
+          "wasd_controlled": 44,
+          "can_power_jump": 45,
+          "linger": 46,
+          "has_collision": 47,
+          "affected_by_gravity": 48,
+          "fire_immune": 49,
+          "dancing": 50,
+          "enchanted": 51,
+          "show_trident_rope": 52,
+          "container_private": 53,
+          "transforming": 54,
+          "spin_attack": 55,
+          "swimming": 56,
+          "bribed": 57,
+          "pregnant": 58,
+          "laying_egg": 59,
+          "rider_can_pick": 60,
+          "transition_sitting": 61,
+          "eating": 62,
+          "laying_down": 63
+        }
+      }
+    ],
+    "MetadataFlags2": [
+      "bitflags",
+      {
+        "type": "zigzag64",
+        "big": true,
+        "shift": true,
+        "flags": {
+          "sneezing": 64,
+          "trusting": 65,
+          "rolling": 66,
+          "scared": 67,
+          "in_scaffolding": 68,
+          "over_scaffolding": 69,
+          "fall_through_scaffolding": 70,
+          "blocking": 71,
+          "transition_blocking": 72,
+          "blocked_using_shield": 73,
+          "blocked_using_damaged_shield": 74,
+          "sleeping": 75,
+          "wants_to_wake": 76,
+          "trade_interest": 77,
+          "door_breaker": 78,
+          "breaking_obstruction": 79,
+          "door_opener": 80,
+          "illager_captain": 81,
+          "stunned": 82,
+          "roaring": 83,
+          "delayed_attacking": 84,
+          "avoiding_mobs": 85,
+          "avoiding_block": 86,
+          "facing_target_to_range_attack": 87,
+          "hidden_when_invisible": 88,
+          "is_in_ui": 89,
+          "stalking": 90,
+          "emoting": 91,
+          "celebrating": 92,
+          "admiring": 93,
+          "celebrating_special": 94
+        }
+      }
+    ],
+    "UpdateBlockFlags": [
+      "bitflags",
+      {
+        "type": "varint",
+        "flags": {
+          "neighbors": 1,
+          "network": 2,
+          "no_graphic": 4,
+          "unused": 8,
+          "priority": 16
+        }
+      }
+    ],
+    "AdventureFlags": [
+      "bitflags",
+      {
+        "type": "varint",
+        "flags": {
+          "world_immutable": 1,
+          "no_pvp": 2,
+          "auto_jump": 32,
+          "allow_flight": 64,
+          "no_clip": 128,
+          "world_builder": 256,
+          "flying": 512,
+          "muted": 1024
+        }
+      }
+    ],
+    "ActionPermissions": [
+      "bitflags",
+      {
+        "type": "varint",
+        "flags": {
+          "mine": 65537,
+          "doors_and_switches": 65538,
+          "open_containers": 65540,
+          "attack_players": 65544,
+          "attack_mobs": 65552,
+          "operator": 65568,
+          "teleport": 65664,
+          "build": 65792,
+          "default": 66048
+        }
+      }
+    ],
+    "CommandFlags": [
+      "bitfield",
+      [
+        {
+          "name": "unused",
+          "size": 6,
+          "signed": false
+        },
+        {
+          "name": "has_semantic_constraint",
+          "size": 1,
+          "signed": false
+        },
+        {
+          "name": "collapse_enum",
+          "size": 1,
+          "signed": false
+        }
+      ]
+    ],
+    "DeltaMoveFlags": [
+      "bitflags",
+      {
+        "type": "lu16",
+        "flags": {
+          "has_x": 1,
+          "has_y": 2,
+          "has_z": 4,
+          "has_rot_x": 8,
+          "has_rot_y": 16,
+          "has_rot_z": 32,
+          "on_ground": 64,
+          "teleport": 128,
+          "force_move": 256
+        }
+      }
+    ],
+    "InputFlag": [
+      "bitflags",
+      {
+        "type": "varint",
+        "flags": {
+          "ascend": 1,
+          "descend": 2,
+          "north_jump": 4,
+          "jump_down": 8,
+          "sprint_down": 16,
+          "change_height": 32,
+          "jumping": 64,
+          "auto_jumping_in_water": 128,
+          "sneaking": 256,
+          "sneak_down": 512,
+          "up": 1024,
+          "down": 2048,
+          "left": 4096,
+          "right": 8192,
+          "up_left": 16384,
+          "up_right": 32768,
+          "want_up": 65536,
+          "want_down": 131072,
+          "want_down_slow": 262144,
+          "want_up_slow": 524288,
+          "sprinting": 1048576,
+          "ascend_scaffolding": 2097152,
+          "descend_scaffolding": 4194304,
+          "sneak_toggle_down": 8388608,
+          "persist_sneak": 16777216,
+          "start_sprinting": 33554432,
+          "stop_sprinting": 67108864,
+          "start_sneaking": 134217728,
+          "stop_sneaking": 134217728,
+          "start_swimming": 268435456,
+          "stop_swimming": 536870912,
+          "start_jumping": 1073741824,
+          "start_gliding": 2147483648,
+          "stop_gliding": 4294967296,
+          "item_interact": 8589934592,
+          "block_action": 17179869184,
+          "item_stack_request": 34359738368
+        }
+      }
+    ],
+    "ArmorDamageType": [
+      "bitflags",
+      {
+        "type": "u8",
+        "flags": {
+          "head": 1,
+          "chest": 2,
+          "legs": 4,
+          "feet": 8
+        }
+      }
+    ]
+  }
+}

--- a/data/latest/proto.yml
+++ b/data/latest/proto.yml
@@ -753,6 +753,10 @@ packet_update_attributes:
    attributes: PlayerAttributes
    tick: varint64
 
+# InventoryTransaction is a packet sent by the client. It essentially exists out of multiple sub-packets,
+# each of which have something to do with the inventory in one way or another. Some of these sub-packets
+# directly relate to the inventory, others relate to interaction with the world, that could potentially
+# result in a change in the inventory.
 packet_inventory_transaction:
    !id: 0x1e
    !bound: both
@@ -821,37 +825,7 @@ packet_player_action:
    runtime_entity_id: varint
    # ActionType is the ID of the action that was executed by the player. It is one of the constants that may
    # be found above.
-   action: zigzag32 =>
-      0: start_break
-      1: abort_break
-      2: stop_break
-      3: get_updated_block
-      4: drop_item
-      5: start_sleeping
-      6: stop_sleeping
-      7: respawn
-      8: jump
-      9: start_sprint
-      10: stop_sprint
-      11: start_sneak
-      12: stop_sneak
-      13: creative_player_destroy_block
-      # sent when spawning in a different dimension to tell the server we spawned
-      14: dimension_change_ack
-      15: start_glide
-      16: stop_glide
-      17: build_denied
-      18: crack_break
-      19: change_skin
-      # no longer used
-      20: set_enchatnment_seed
-      21: swimming
-      22: stop_swimming
-      23: start_spin_attack
-      24: stop_spin_attack
-      25: ineract_block
-      26: predict_break
-      27: continue_break
+   action: Action
    # BlockPosition is the position of the target block, if the action with the ActionType set concerned a
    # block. If that is not the case, the block position will be zero.
    position: BlockCoordinates
@@ -2127,10 +2101,11 @@ packet_player_auth_input:
    # InputMode specifies the way that the client inputs data to the screen. It is one of the constants that
    # may be found above.
    input_mode: varint =>
-      0: mouse
-      1: touch
-      2: game_pad
-      3: motion_controller
+      0: unknown
+      1: mouse
+      2: touch
+      3: game_pad
+      4: motion_controller
    # PlayMode specifies the way that the player is playing. The values it holds, which are rather random,
    # may be found above.
    play_mode: varint =>
@@ -2154,49 +2129,67 @@ packet_player_auth_input:
    # Delta was the delta between the old and the new position. There isn't any practical use for this field
    # as it can be calculated by the server itself.
    delta: vec3f
+   transaction: input_data.item_interact ?
+      if true:
+         legacy: TransactionLegacy
+         actions: TransactionActions
+         data: TransactionUseItem
+   item_stack_request: input_data.item_stack_request ?
+      if true: ItemStackRequest
+   block_action: input_data.block_action ?
+      if true: []zigzag32
+         action: Action
+         _: action?
+            if start_break or abort_break or crack_break or predict_break or continue_break:
+               # BlockPosition is the position of the target block, if the action with the ActionType set concerned a
+               # block. If that is not the case, the block position will be zero.
+               position: BlockCoordinates
+               # BlockFace is the face of the target block that was touched. If the action with the ActionType set
+               # concerned a block. If not, the face is always 0.
+               face: zigzag32
 
 #TODO: update to use the new `shift` option in bitflags
 InputFlag: [ "bitflags", {
-   "type": "varint",
-   "flags": {
-      "ascend":             0b1,
-      "descend":            0b10,
-      "north_jump":         0b100,
-      "jump_down":          0b1000,
-      "sprint_down":        0b10000,
-      "change_height":      0b100000,
-      "jumping":            0b1000000,
-      "auto_jumping_in_water": 0b10000000,
-      "sneaking":           0b100000000,
-      "sneak_down":         0b1000000000,
-      "up":                 0b10000000000,
-      "down":               0b100000000000,
-      "left":               0b1000000000000,
-      "right":              0b10000000000000,
-      "up_left":            0b100000000000000,
-      "up_right":           0b1000000000000000,
-      "want_up":            0b10000000000000000,
-      "want_down":          0b100000000000000000,
-      "want_down_slow":     0b1000000000000000000,
-      "want_up_slow":       0b10000000000000000000,
-      "sprinting":          0b100000000000000000000,
-      "ascend_scaffolding": 0b1000000000000000000000,
-      "descend_scaffolding": 0b10000000000000000000000,
-      "sneak_toggle_down":  0b100000000000000000000000,
-      "persist_sneak":      0b1000000000000000000000000,
-      "start_sprinting":    0b10000000000000000000000000,
-      "stop_sprinting":     0b100000000000000000000000000,
-      "start_sneaking":     0b1000000000000000000000000000,
-      "stop_sneaking":      0b1000000000000000000000000000,
-      "start_swimming":     0b10000000000000000000000000000,
-      "stop_swimming":      0b100000000000000000000000000000,
-      "start_jumping":      0b1000000000000000000000000000000,
-      "start_gliding":      0b10000000000000000000000000000000,
-      "stop_gliding":       0b100000000000000000000000000000000,
-      "item_interact":      0b1000000000000000000000000000000000,
-      "block_action":       0b10000000000000000000000000000000000,
-      "item_stack_request": 0b100000000000000000000000000000000000
-   }
+   "type": "varint64", "big": true,
+   "flags": [
+      "ascend",
+      "descend",
+      "north_jump",
+      "jump_down",
+      "sprint_down",
+      "change_height",
+      "jumping",
+      "auto_jumping_in_water",
+      "sneaking",
+      "sneak_down",
+      "up",
+      "down",
+      "left",
+      "right",
+      "up_left",
+      "up_right",
+      "want_up",
+      "want_down",
+      "want_down_slow",
+      "want_up_slow",
+      "sprinting",
+      "ascend_scaffolding",
+      "descend_scaffolding",
+      "sneak_toggle_down",
+      "persist_sneak",
+      "start_sprinting",
+      "stop_sprinting",
+      "start_sneaking",
+      "stop_sneaking",
+      "start_swimming",
+      "stop_swimming",
+      "start_jumping",
+      "start_gliding",
+      "stop_gliding",
+      "item_interact",
+      "block_action",
+      "item_stack_request"
+   ]
 }]
 
 packet_creative_content:
@@ -2209,10 +2202,14 @@ packet_player_enchant_options:
    !bound: client
    enchant_options: EnchantOptions
 
+# ItemStackRequest is sent by the client to change item stacks in an inventory. It is essentially a
+# replacement of the InventoryTransaction packet added in 1.16 for inventory specific actions, such as moving
+# items around or crafting. The InventoryTransaction packet is still used for actions such as placing blocks
+# and interacting with entities.
 packet_item_stack_request:
    !id: 0x93
    !bound: server
-   requests: ItemStackRequests
+   requests: ItemStackRequest[]varint
 
 packet_item_stack_response:
    !id: 0x94

--- a/data/latest/proto.yml
+++ b/data/latest/proto.yml
@@ -2155,7 +2155,7 @@ packet_player_auth_input:
    # as it can be calculated by the server itself.
    delta: vec3f
 
-
+#TODO: update to use the new `shift` option in bitflags
 InputFlag: [ "bitflags", {
    "type": "varint",
    "flags": {

--- a/data/latest/proto.yml
+++ b/data/latest/proto.yml
@@ -1,7 +1,7 @@
 # Created from MiNET and gophertunnel docs
 # The version below is the latest version this protocol schema was updated for.
 # The output protocol.json will be in the folder for the version
-!version: 1.16.201
+!version: 1.16.210
 
 # Some ProtoDef aliases
 string: ["pstring",{"countType":"varint"}]
@@ -217,7 +217,7 @@ packet_start_game:
    player_gamemode: GameMode
    # The spawn position of the player in the world. In servers this is often the same as the 
    # world's spawn position found below.
-   spawn: vec3f
+   player_position: vec3f
    # The pitch and yaw of the player
    rotation: vec2f
    # The seed used to generate the world. Unlike in Java edition, the seed is a 32bit Integer here.
@@ -334,6 +334,13 @@ packet_start_game:
    # Specifies if the world was a trial world, meaning features are limited and there 
    # is a time limit on the world.
    is_trial: bool
+   
+   # MovementType specifies the way the server handles player movement. Available options are
+   # packet.AuthoritativeMovementModeClient, packet.AuthoritativeMovementModeServer and
+   # packet.AuthoritativeMovementModeServerWithRewind, where server the server authoritative types result
+   # in the client sending PlayerAuthInput packets instead of MovePlayer packets and the rewind mode
+   # requires sending the tick of movement and several actions.
+   #
    # Specifies if the client or server is authoritative over the movement of the player, 
    # meaning it controls the movement of it. 
    ## https://github.com/pmmp/PocketMine-MP/blob/a43b46a93cb127f037c879b5d8c29cda251dd60c/src/pocketmine/network/mcpe/protocol/types/PlayerMovementType.php#L26
@@ -341,7 +348,16 @@ packet_start_game:
       0: client
       1: server
       # PlayerAuthInputPacket + a bunch of junk that solves a nonexisting problem
-      2: server_v2_rewind
+      2: server_with_rewind
+   # RewindHistorySize is the amount of history to keep at maximum if MovementType is
+   # packet.AuthoritativeMovementModeServerWithRewind.
+   rewind_history_size: zigzag32
+   # ServerAuthoritativeBlockBreaking specifies if block breaking should be sent through
+   # packet.PlayerAuthInput or not. This field is somewhat redundant as it is always enabled if
+   # MovementType is packet.AuthoritativeMovementModeServer or
+   # packet.AuthoritativeMovementModeServerWithRewind
+   server_authoritative_block_breaking: bool
+
    # The total time in ticks that has elapsed since the start of the world.
    current_tick: li64
    # The seed used to seed the random used to produce enchantments in the enchantment table. 
@@ -508,13 +524,36 @@ packet_rider_jump:
    !bound: both
    jump_strength: zigzag32
 
+# UpdateBlock is sent by the server to update a block client-side, without resending the entire chunk that
+# the block is located in. It is particularly useful for small modifications like block breaking/placing.
 packet_update_block:
    !id: 0x15
    !bound: client
-   coordinates: BlockCoordinates
+   # Position is the block position at which a block is updated.
+   position: BlockCoordinates
+   # NewBlockRuntimeID is the runtime ID of the block that is placed at Position after sending the packet
+   # to the client.
    block_runtime_id: varint
-   block_priority: varint
-   storage: varint
+   # Flags is a combination of flags that specify the way the block is updated client-side. It is a
+   # combination of the flags above, but typically sending only the BlockUpdateNetwork flag is sufficient.
+   flags: UpdateBlockFlags
+   # Layer is the world layer on which the block is updated. For most blocks, this is the first layer, as
+   # that layer is the default layer to place blocks on, but for blocks inside of each other, this differs.
+   layer: varint
+
+
+UpdateBlockFlags: [ "bitflags",
+   {
+      "type": "varint",
+      "flags": {
+         "neighbors": 1,
+         "network": 2,
+         "no_graphic": 0b100,
+         "unused": 0b1000,
+         "priority": 0b10000,
+      }
+   }
+]
 
 packet_add_painting:
    !id: 0x16
@@ -802,7 +841,7 @@ packet_player_action:
       15: start_glide
       16: stop_glide
       17: build_denied
-      18: continue_break
+      18: crack_break
       19: change_skin
       # no longer used
       20: set_enchatnment_seed
@@ -811,6 +850,8 @@ packet_player_action:
       23: start_spin_attack
       24: stop_spin_attack
       25: ineract_block
+      26: predict_break
+      27: continue_break
    # BlockPosition is the position of the target block, if the action with the ActionType set concerned a
    # block. If that is not the case, the block position will be zero.
    position: BlockCoordinates
@@ -1054,13 +1095,15 @@ ActionPermissions: [ "bitflags",
    {
       "type": "varint",
       "flags": {
-         "build_and_mine": 0x10001,
+         "mine": 0x10001,
          "doors_and_switches": 0x10002,
          "open_containers": 0x10004,
          "attack_players": 0x10008,
          "attack_mobs": 0x10010,
          "operator": 0x10020,
          "teleport": 0x10080,
+         "build": 0x10100,
+         "default": 0x10200
       }
    }
 ]
@@ -1171,7 +1214,14 @@ packet_event:
       14: pet_died 
       15: cauldron_block_used 
       16: composter_block_used 
-      17: bell_block_used 
+      17: bell_block_used
+      18: actor_definition
+      19: raid_update
+      20: player_movement_anomaly
+      21: player_moement_corrected
+      22: honey_harvested
+      23: target_block_hit
+      24: piglin_barter
    use_player_id: u8
    event_data: restBuffer # Unknown data, TODO: add
 
@@ -1317,13 +1367,13 @@ packet_available_commands:
                4: wildcard_int
                5: operator
                6: target
-               14: file_path
-               29: string
-               37: position
-               41: message
-               43: raw_text
-               46: json
-               53: command
+               16: file_path
+               32: string
+               40: position
+               44: message
+               46: raw_text
+               50: json
+               63: command
             # In MC, this + prior field are combined to one 32bit bitfield
             enum_type: lu16 =>
                0x10: valid
@@ -1388,9 +1438,12 @@ packet_command_output:
    # command request was from, such as the player itself or a websocket server. The client forwards the
    # messages in this packet to the right origin, depending on what is sent here.
    origin: CommandOrigin
-   # OutputType specifies the type of output that is sent. The OutputType sent by vanilla games appears to
-   # be 3, which seems to work.
-   output_type: i8
+   # OutputType specifies the type of output that is sent.
+   output_type: i8 =>
+      1: last
+      2: silent
+      3: all
+      4: data_set
    # SuccessCount is the amount of times that a command was executed successfully as a result of the command
    # that was requested. For servers, this is usually a rather meaningless fields, but for vanilla, this is
    # applicable for commands created with Functions.
@@ -1410,6 +1463,9 @@ packet_command_output:
       # such as the position that a player was teleported to or the effect that was applied to an entity.
       # These parameters only apply for the Minecraft built-in command output.
       paramaters: string[]varint
+   data_set: output_type ?
+      if data_set: string
+      default: void
 
 
 # UpdateTrade is sent by the server to update the trades offered by a villager to a player. It is sent at the
@@ -1516,13 +1572,34 @@ packet_stop_sound:
    name: string
    stop_all: bool
 
+# SetTitle is sent by the server to make a title, subtitle or action bar shown to a player. It has several
+# fields that allow setting the duration of the titles.
 packet_set_title:
    !id: 0x58
    !bound: client
-   type: zigzag32
+   # ActionType is the type of the action that should be executed upon the title of a player. It is one of
+   # the constants above and specifies the response of the client to the packet.
+   type: zigzag32 =>
+      0: clear
+      1: reset
+      2: set_title
+      3: set_subtitle
+      4: action_bar_message
+      5: set_durations
+      6: set_title_json
+      7: set_subtitle_json
+      8: action_bar_message_json
+   # Text is the text of the title, which has a different meaning depending on the ActionType that the
+   # packet has. The text is the text of a title, subtitle or action bar, depending on the type set.
    text: string
+   # FadeInDuration is the duration that the title takes to fade in on the screen of the player. It is
+   # measured in 20ths of a second (AKA in ticks).
    fade_in_time: zigzag32
+   # RemainDuration is the duration that the title remains on the screen of the player. It is measured in
+   # 20ths of a second (AKA in ticks).
    stay_time: zigzag32
+   # FadeOutDuration is the duration that the title takes to fade out of the screen of the player. It is
+   # measured in 20ths of a second (AKA in ticks).
    fade_out_time: zigzag32
 
 packet_add_behavior_tree:
@@ -1673,15 +1750,38 @@ packet_lab_table:
    lab_table_z: varint
    reaction_type: u8
 
+# UpdateBlockSynced is sent by the server to synchronise the falling of a falling block entity with the
+# transitioning back and forth from and to a solid block. It is used to prevent the entity from flickering,
+# and is used in places such as the pushing of blocks with pistons.
 packet_update_block_synced:
    !id: 0x6e
    !bound: client
-   coordinates: BlockCoordinates
+   # Position is the block position at which a block is updated.
+   position: BlockCoordinates
+   # NewBlockRuntimeID is the runtime ID of the block that is placed at Position after sending the packet
+   # to the client.
    block_runtime_id: varint
-   block_priority: varint
-   data_layer_id: varint
-   unknown0: varint
-   unknown1: varint
+   # Flags is a combination of flags that specify the way the block is updated client-side. It is a
+   # combination of the flags above, but typically sending only the BlockUpdateNetwork flag is sufficient.
+   flags: UpdateBlockFlags
+   # Layer is the world layer on which the block is updated. For most blocks, this is the first layer, as
+   # that layer is the default layer to place blocks on, but for blocks inside of each other, this differs.
+   layer: varint
+   # EntityUniqueID is the unique ID of the falling block entity that the block transitions to or that the
+   # entity transitions from.
+   # Note that for both possible values for TransitionType, the EntityUniqueID should point to the falling
+   # block entity involved.
+   entity_unique_id: varint
+   # TransitionType is the type of the transition that happened. It is either BlockToEntityTransition, when
+   # a block placed becomes a falling entity, or EntityToBlockTransition, when a falling entity hits the
+   # ground and becomes a solid block again.
+   transition_type: varint =>
+      # For falling sand, when a sand turns to an entity
+      0: entity
+      # When sand turns back to a new block
+      1: create
+      2: destroy
+
 
 # MoveActorDelta is sent by the server to move an entity. The packet is specifically optimised to save as
 # much space as possible, by only writing non-zero fields.
@@ -2055,34 +2155,47 @@ packet_player_auth_input:
    # as it can be calculated by the server itself.
    delta: vec3f
 
+
 InputFlag: [ "bitflags", {
    "type": "varint",
    "flags": {
-      "ascend": 0b1,
-      "descend": 0b10,
-      "north_jump": 0b100,
-      "jump_down": 0b1000,
-      "sprint_down": 0b10000,
-      "change_height": 0b100000,
-      "jumping": 0b1000000,
+      "ascend":             0b1,
+      "descend":            0b10,
+      "north_jump":         0b100,
+      "jump_down":          0b1000,
+      "sprint_down":        0b10000,
+      "change_height":      0b100000,
+      "jumping":            0b1000000,
       "auto_jumping_in_water": 0b10000000,
-      "sneaking": 0b100000000,
-      "sneak_down": 0b1000000000,
-      "up": 0b10000000000,
-      "down": 0b100000000000,
-      "left": 0b1000000000000,
-      "right": 0b10000000000000,
-      "up_left": 0b100000000000000,
-      "up_right": 0b1000000000000000,
-      "want_up": 0b10000000000000000,
-      "want_down": 0b100000000000000000,
-      "want_down_slow": 0b1000000000000000000,
-      "want_up_slow": 0b10000000000000000000,
-      "sprinting": 0b100000000000000000000,
+      "sneaking":           0b100000000,
+      "sneak_down":         0b1000000000,
+      "up":                 0b10000000000,
+      "down":               0b100000000000,
+      "left":               0b1000000000000,
+      "right":              0b10000000000000,
+      "up_left":            0b100000000000000,
+      "up_right":           0b1000000000000000,
+      "want_up":            0b10000000000000000,
+      "want_down":          0b100000000000000000,
+      "want_down_slow":     0b1000000000000000000,
+      "want_up_slow":       0b10000000000000000000,
+      "sprinting":          0b100000000000000000000,
       "ascend_scaffolding": 0b1000000000000000000000,
       "descend_scaffolding": 0b10000000000000000000000,
-      "sneak_toggle_down": 0b100000000000000000000000,
-      "persist_sneak": 0b1000000000000000000000000,
+      "sneak_toggle_down":  0b100000000000000000000000,
+      "persist_sneak":      0b1000000000000000000000000,
+      "start_sprinting":    0b10000000000000000000000000,
+      "stop_sprinting":     0b100000000000000000000000000,
+      "start_sneaking":     0b1000000000000000000000000000,
+      "stop_sneaking":      0b1000000000000000000000000000,
+      "start_swimming":     0b10000000000000000000000000000,
+      "stop_swimming":      0b100000000000000000000000000000,
+      "start_jumping":      0b1000000000000000000000000000000,
+      "start_gliding":      0b10000000000000000000000000000000,
+      "stop_gliding":       0b100000000000000000000000000000000,
+      "item_interact":      0b1000000000000000000000000000000000,
+      "block_action":       0b10000000000000000000000000000000000,
+      "item_stack_request": 0b100000000000000000000000000000000000
    }
 }]
 
@@ -2262,6 +2375,11 @@ packet_camera_shake:
    # Type is the type of shake, and is one of the constants listed above. The different type affects how
    # the shake looks in game.
    type: u8
+   # Action is the action to be performed, and is one of the constants listed above. Currently the
+   # different actions will either add or stop shaking the client.
+   action: u8 =>
+      0: add
+      1: stop
 
 # PlayerFog is sent by the server to render the different fogs in the Stack. The types of fog are controlled
 # by resource packs to change how they are rendered, and the ability to create custom fog.
@@ -2308,3 +2426,28 @@ packet_filter_text_packet:
    # FromServer indicates if the packet was sent by the server or not.
    from_server: bool
 
+# ClientBoundDebugRenderer is sent by the server to spawn an outlined cube on client-side.
+packet_debug_renderer:
+   !id: 0xa4
+   !bound: client
+   # Type is the type of action. It is one of the constants above.
+   type: li32 =>
+      1: clear
+      2: add_cube
+   _: type ?
+      if clear: void
+      if add_cube:
+         # Text is the text that is displayed above the debug.
+         text: string
+         # Position is the position to spawn the debug on.
+         position: vec3f
+         # Red is the red value from the RGBA colour rendered on the debug.
+         red: lf32
+         # Green is the green value from the RGBA colour rendered on the debug.
+         green: lf32
+         # Blue is the blue value from the RGBA colour rendered on the debug.
+         blue: lf32
+         # Alpha is the alpha value from the RGBA colour rendered on the debug.
+         alpha: lf32
+         # Duration is how long the debug will last in the world for. It is measured in milliseconds.
+         duration: li64

--- a/data/latest/types.yaml
+++ b/data/latest/types.yaml
@@ -262,110 +262,112 @@ MetadataDictionary: []varint
          if vec3f: vec3f
 
 MetadataFlags1: [ "bitflags", {
-   "type": "zigzag64", "big": true, "shift": true,
-   "flags": {
-      "onfire": 0,
-      "sneaking": 1,
-      "riding": 2,
-      "sprinting": 3,
-      "action": 4,
-      "invisible": 5,
-      "tempted": 6,
-      "inlove": 7,
-      "saddled": 8,
-      "powered": 9,
-      "ignited": 10,
-      "baby": 11,
-      "converting": 12,
-      "critical": 13,
-      "can_show_nametag": 14,
-      "always_show_nametag": 15,
-      "no_ai": 16,
-      "silent": 17,
-      "wallclimbing": 18,
-      "can_climb": 19,
-      "swimmer": 20,
-      "can_fly": 21,
-      "walker": 22,
-      "resting": 23,
-      "sitting": 24,
-      "angry": 25,
-      "interested": 26,
-      "charged": 27,
-      "tamed": 28,
-      "orphaned": 29,
-      "leashed": 30,
-      "sheared": 31,
-      "gliding": 32,
-      "elder": 33,
-      "moving": 34,
-      "breathing": 35,
-      "chested": 36,
-      "stackable": 37,
-      "showbase": 38,
-      "rearing": 39,
-      "vibrating": 40,
-      "idling": 41,
-      "evoker_spell": 42,
-      "charge_attack": 43,
-      "wasd_controlled": 44,
-      "can_power_jump": 45,
-      "linger": 46,
-      "has_collision": 47,
-      "affected_by_gravity": 48,
-      "fire_immune": 49,
-      "dancing": 50,
-      "enchanted": 51,
-      "show_trident_rope": 52, # tridents show an animated rope when enchanted with loyalty after they are thrown and return to their owner. to be combined with data_owner_eid
-      "container_private": 53, #inventory is private, doesn't drop contents when killed if true
-      "transforming": 54,
-      "spin_attack": 55,
-      "swimming": 56,
-      "bribed": 57, #dolphins have this set when they go to find treasure for the player
-      "pregnant": 58,
-      "laying_egg": 59,
-      "rider_can_pick": 60, #???
-      "transition_sitting": 61,
-      "eating": 62,
-      "laying_down": 63,
-   }
+   "type": "zigzag64", 
+   "big": true,
+   "flags": [
+      "onfire",
+      "sneaking",
+      "riding",
+      "sprinting",
+      "action",
+      "invisible",
+      "tempted",
+      "inlove",
+      "saddled",
+      "powered",
+      "ignited",
+      "baby",
+      "converting",
+      "critical",
+      "can_show_nametag",
+      "always_show_nametag",
+      "no_ai",
+      "silent",
+      "wallclimbing",
+      "can_climb",
+      "swimmer",
+      "can_fly",
+      "walker",
+      "resting",
+      "sitting",
+      "angry",
+      "interested",
+      "charged",
+      "tamed",
+      "orphaned",
+      "leashed",
+      "sheared",
+      "gliding",
+      "elder",
+      "moving",
+      "breathing",
+      "chested",
+      "stackable",
+      "showbase",
+      "rearing",
+      "vibrating",
+      "idling",
+      "evoker_spell",
+      "charge_attack",
+      "wasd_controlled",
+      "can_power_jump",
+      "linger",
+      "has_collision",
+      "affected_by_gravity",
+      "fire_immune",
+      "dancing",
+      "enchanted",
+      "show_trident_rope", # tridents show an animated rope when enchanted with loyalty after they are thrown and return to their owner. to be combined with data_owner_eid
+      "container_private", #inventory is private, doesn't drop contents when killed if true
+      "transforming",
+      "spin_attack",
+      "swimming",
+      "bribed", #dolphins have this set when they go to find treasure for the player
+      "pregnant",
+      "laying_egg",
+      "rider_can_pick", #???
+      "transition_sitting",
+      "eating",
+      "laying_down"
+   ]
 }]
 
 MetadataFlags2: [ "bitflags", {
-   "type": "zigzag64","big": true, "shift": true,
-   "flags": {
-      "sneezing": 64,
-      "trusting": 65,
-      "rolling": 66,
-      "scared": 67,
-      "in_scaffolding": 68,
-      "over_scaffolding": 69,
-      "fall_through_scaffolding": 70,
-      "blocking": 71, #shield
-      "transition_blocking": 72,
-      "blocked_using_shield": 73,
-      "blocked_using_damaged_shield": 74,
-      "sleeping": 75,
-      "wants_to_wake": 76,
-      "trade_interest": 77,
-      "door_breaker": 78, #...
-      "breaking_obstruction": 79,
-      "door_opener": 80, #...
-      "illager_captain": 81,
-      "stunned": 82,
-      "roaring": 83,
-      "delayed_attacking": 84,
-      "avoiding_mobs": 85,
-      "avoiding_block": 86,
-      "facing_target_to_range_attack": 87,
-      "hidden_when_invisible": 88, #??????????????????
-      "is_in_ui": 89,
-      "stalking": 90,
-      "emoting": 91,
-      "celebrating": 92,
-      "admiring": 93,
-      "celebrating_special": 94,
-   }
+   "type": "zigzag64", 
+   "big": true,
+   "flags": [
+      "sneezing",
+      "trusting",
+      "rolling",
+      "scared",
+      "in_scaffolding",
+      "over_scaffolding",
+      "fall_through_scaffolding",
+      "blocking", #shield
+      "transition_blocking",
+      "blocked_using_shield",
+      "blocked_using_damaged_shield",
+      "sleeping",
+      "wants_to_wake",
+      "trade_interest",
+      "door_breaker", #...
+      "breaking_obstruction",
+      "door_opener", #...
+      "illager_captain",
+      "stunned",
+      "roaring",
+      "delayed_attacking",
+      "avoiding_mobs",
+      "avoiding_block",
+      "facing_target_to_range_attack",
+      "hidden_when_invisible", #??????????????????
+      "is_in_ui",
+      "stalking",
+      "emoting",
+      "celebrating",
+      "admiring",
+      "celebrating_special"
+   ]
 }]
 
 Link:
@@ -400,31 +402,44 @@ PlayerAttributes: []varint
    default: lf32
    name: string
 
-Transaction:
-   # LegacyRequestID is an ID that is only non-zero at times when sent by the client. The server should
-   # always send 0 for this. When this field is not 0, the LegacySetItemSlots slice below will have values
-   # in it.
-   # LegacyRequestID ties in with the ItemStackResponse packet. If this field is non-0, the server should
-   # respond with an ItemStackResponse packet. Some inventory actions such as dropping an item out of the
-   # hotbar are still one using this packet, and the ItemStackResponse packet needs to tie in with it.
-   legacy_request_id: zigzag32
-   # `legacy_transactions` are only present if the LegacyRequestID is non-zero. These item slots inform the
-   # server of the slots that were changed during the inventory transaction, and the server should send
-   # back an ItemStackResponse packet with these slots present in it. (Or false with no slots, if rejected.)
-   legacy_transactions: legacy_request_id?
-      if 0: void
-      default: []varint
-         container_id: u8
-         changed_slots: []varint
-            slot_id: u8
-   transaction_type: varint =>
-      0: normal
-      1: inventory_mismatch
-      2: item_use
-      3: item_use_on_entity
-      4: item_release
+# UseItemTransactionData represents an inventory transaction data object sent when the client uses an item on
+# a block. Also used in PlayerAuthoritativeInput packet
+TransactionUseItem:
+   # ActionType is the type of the UseItem inventory transaction. It is one of the action types found above,
+   # and specifies the way the player interacted with the block.
+   action_type: varint =>
+      0: click_block
+      1: click_air
+      2: break_block
+   # BlockPosition is the position of the block that was interacted with. This is only really a correct
+   # block position if ActionType is not UseItemActionClickAir.
+   block_position: BlockCoordinates
+   # BlockFace is the face of the block that was interacted with. When clicking the block, it is the face
+   # clicked. When breaking the block, it is the face that was last being hit until the block broke.
+   face: varint
+   # HotBarSlot is the hot bar slot that the player was holding while clicking the block. It should be used
+   # to ensure that the hot bar slot and held item are correctly synchronised with the server.
+   hotbar_slot: varint
+   # HeldItem is the item that was held to interact with the block. The server should check if this item
+   # is actually present in the HotBarSlot.
+   held_item: Item
+   # Position is the position of the player at the time of interaction. For clicking a block, this is the
+   # position at that time, whereas for breaking the block it is the position at the time of breaking.
+   player_pos: vec3f
+   # ClickedPosition is the position that was clicked relative to the block's base coordinate. It can be
+   # used to find out exactly where a player clicked the block.
+   click_pos: vec3f
+   # BlockRuntimeID is the runtime ID of the block that was clicked. It may be used by the server to verify
+   # that the player's world client-side is synchronised with the server's.
+   block_runtime_id: varint
+
+# Actions is a list of actions that took place, that form the inventory transaction together. Each of
+# these actions hold one slot in which one item was changed to another. In general, the combination of
+# all of these actions results in a balanced inventory transaction. This should be checked to ensure that
+# no items are cheated into the inventory.
+TransactionActions:
    network_ids: bool
-   inventory_actions: []varint
+   actions: []varint
       source_type: varint =>
          0: container
          1: global
@@ -444,40 +459,47 @@ Transaction:
       old_item: Item
       new_item: Item
       new_item_stack_id: ../network_ids?
-         if true:  zigzag32
+         if true: zigzag32
          default: void
+
+# The Minecraft bedrock inventory system was refactored, but not all inventory actions use the new packet.
+# This data structure holds actions that have not been updated to the new system.
+TransactionLegacy:
+   # LegacyRequestID is an ID that is only non-zero at times when sent by the client. The server should
+   # always send 0 for this. When this field is not 0, the LegacySetItemSlots slice below will have values
+   # in it.
+   # LegacyRequestID ties in with the ItemStackResponse packet. If this field is non-0, the server should
+   # respond with an ItemStackResponse packet. Some inventory actions such as dropping an item out of the
+   # hotbar are still one using this packet, and the ItemStackResponse packet needs to tie in with it.
+   legacy_request_id: zigzag32
+   # `legacy_transactions` are only present if the LegacyRequestID is non-zero. These item slots inform the
+   # server of the slots that were changed during the inventory transaction, and the server should send
+   # back an ItemStackResponse packet with these slots present in it. (Or false with no slots, if rejected.)
+   legacy_transactions: legacy_request_id?
+      if 0: void
+      default: []varint
+         container_id: u8
+         changed_slots: []varint
+            slot_id: u8
+
+Transaction:
+   # Old transaction system data
+   legacy: TransactionLegacy
+   # What type of transaction took place
+   transaction_type: varint =>
+      0: normal
+      1: inventory_mismatch
+      2: item_use
+      3: item_use_on_entity
+      4: item_release
+   # The list of inventory internal actions in this packet, e.g. inventory GUI actions
+   actions: TransactionActions
+   # Extra data if an intenal inventory transaction did not take place, e.g. use of an item 
    transaction_data: transaction_type?
       if normal or inventory_mismatch: void
       # UseItemTransactionData represents an inventory transaction data object sent when the client uses an item on
       # a block.
-      if item_use:
-         # ActionType is the type of the UseItem inventory transaction. It is one of the action types found above,
-         # and specifies the way the player interacted with the block.
-         action_type: varint =>
-            0: click_block
-            1: click_air
-            2: break_block
-         # BlockPosition is the position of the block that was interacted with. This is only really a correct
-         # block position if ActionType is not UseItemActionClickAir.
-         block_position: BlockCoordinates
-         # BlockFace is the face of the block that was interacted with. When clicking the block, it is the face
-         # clicked. When breaking the block, it is the face that was last being hit until the block broke.
-         face: varint
-         # HotBarSlot is the hot bar slot that the player was holding while clicking the block. It should be used
-         # to ensure that the hot bar slot and held item are correctly synchronised with the server.
-         hotbar_slot: varint
-         # HeldItem is the item that was held to interact with the block. The server should check if this item
-         # is actually present in the HotBarSlot.
-         held_item: Item
-         # Position is the position of the player at the time of interaction. For clicking a block, this is the
-         # position at that time, whereas for breaking the block it is the position at the time of breaking.
-         player_pos: vec3f
-         # ClickedPosition is the position that was clicked relative to the block's base coordinate. It can be
-         # used to find out exactly where a player clicked the block.
-         click_pos: vec3f
-         # BlockRuntimeID is the runtime ID of the block that was clicked. It may be used by the server to verify
-         # that the player's world client-side is synchronised with the server's.
-         block_runtime_id: varint
+      if item_use: TransactionUseItem
       # UseItemOnEntityTransactionData represents an inventory transaction data object sent when the client uses
       # an item on an entity.
       if item_use_on_entity:
@@ -698,15 +720,48 @@ EnchantOptions: []varint
    name: string
    option_id: zigzag32
 
+Action: zigzag32 =>
+   0: start_break
+   1: abort_break
+   2: stop_break
+   3: get_updated_block
+   4: drop_item
+   5: start_sleeping
+   6: stop_sleeping
+   7: respawn
+   8: jump
+   9: start_sprint
+   10: stop_sprint
+   11: start_sneak
+   12: stop_sneak
+   13: creative_player_destroy_block
+   # sent when spawning in a different dimension to tell the server we spawned
+   14: dimension_change_ack
+   15: start_glide
+   16: stop_glide
+   17: build_denied
+   18: crack_break
+   19: change_skin
+   # no longer used
+   20: set_enchatnment_seed
+   21: swimming
+   22: stop_swimming
+   23: start_spin_attack
+   24: stop_spin_attack
+   25: ineract_block
+   26: predict_break
+   27: continue_break
 
 StackRequestSlotInfo:
    container_id: u8
    slot_id: u8
    stack_id: zigzag32
 
-#
-
-ItemStackRequests: []varint
+# ItemStackRequest is sent by the client to change item stacks in an inventory. It is essentially a
+# replacement of the InventoryTransaction packet added in 1.16 for inventory specific actions, such as moving
+# items around or crafting. The InventoryTransaction packet is still used for actions such as placing blocks
+# and interacting with entities.
+ItemStackRequest:
    # RequestID is a unique ID for the request. This ID is used by the server to send a response for this
    # specific request in the ItemStackResponse packet.
    request_id: zigzag32
@@ -836,10 +891,10 @@ ItemStackRequests: []varint
 
 # ItemStackResponse is a response to an individual ItemStackRequest.
 ItemStackResponses: []varint
-	# Status specifies if the request with the RequestID below was successful. If this is the case, the
-	# ContainerInfo below will have information on what slots ended up changing. If not, the container info
-	# will be empty.
-	# A non-0 status means an error occurred and will result in the action being reverted.
+   # Status specifies if the request with the RequestID below was successful. If this is the case, the
+   # ContainerInfo below will have information on what slots ended up changing. If not, the container info
+   # will be empty.
+   # A non-0 status means an error occurred and will result in the action being reverted.
    status: u8 =>
       0: ok
       1: error

--- a/data/latest/types.yaml
+++ b/data/latest/types.yaml
@@ -607,6 +607,7 @@ SkinImage:
 
 Skin:
    skin_id: string
+   play_fab_id: string
    skin_resource_pack: string
    skin_data: SkinImage
    animations: []li32

--- a/data/latest/types.yaml
+++ b/data/latest/types.yaml
@@ -117,7 +117,7 @@ vec2f:
 MetadataDictionary: []varint
    # https://github.com/pmmp/PocketMine-MP/blob/stable/src/pocketmine/entity/Entity.php#L101
    key: varint =>
-      0: index
+      0: flags
       1: health #int (minecart/boat)
       2: variant #int
       3: color #byte
@@ -175,66 +175,68 @@ MetadataDictionary: []varint
       57: rider_rotation_locked #byte
       58: rider_max_rotation #float
       59: rider_min_rotation #float
-      60: area_effect_cloud_radius #float
-      61: area_effect_cloud_waiting #int
-      62: area_effect_cloud_particle_id #int
-      63: shulker_peek_id #int
-      64: shulker_attach_face #byte
-      65: shulker_attached #short
-      66: shulker_attach_pos
-      67: trading_player_eid #long
-      68: trading_career
-      69: has_command_block
-      70: command_block_command #string
-      71: command_block_last_output #string
-      72: command_block_track_output #byte
-      73: controlling_rider_seat_number #byte
-      74: strength #int
-      75: max_strength #int
-      76: spell_casting_color #int
-      77: limited_life
-      78: armor_stand_pose_index # int
-      79: ender_crystal_time_offset # int
-      80: always_show_nametag # byte
-      81: color_2 # byte
-      82: name_author
-      83: score_tag #String
-      84: balloon_attached_entity # long
-      85: pufferfish_size
-      86: bubble_time
-      87: agent
-      88: sitting_amount
-      89: sitting_amount_previous
-      90: eating_counter
-      91: flags_extended
-      92: laying_amount
-      93: laying_amount_previous
-      94: duration
-      95: spawn_time
-      96: change_rate
-      97: change_on_pickup
-      98: pickup_count
-      99: interact_text
-      100: trade_tier
-      101: max_trade_tier
-      102: trade_experience
-      103: skin_id
-      104: spawning_frames
-      105: command_block_tick_delay
-      106: command_block_execute_on_first_tick
-      107: ambient_sound_interval
-      108: ambient_sound_interval_range
-      109: ambient_sound_event_name
-      110: fall_damage_multiplier
-      111: name_raw_text
-      112: can_ride_target
-      113: low_tier_cured_discount
-      114: high_tier_cured_discount
-      115: nearby_cured_discount
-      116: nearby_cured_discount_timestamp
-      117: hitbox
-      118: is_buoyant
-      119: buoyancy_data
+      60: rider_rotation_offset
+      61: area_effect_cloud_radius #float
+      62: area_effect_cloud_waiting #int
+      63: area_effect_cloud_particle_id #int
+      64: shulker_peek_id #int
+      65: shulker_attach_face #byte
+      66: shulker_attached #short
+      67: shulker_attach_pos
+      68: trading_player_eid #long
+      69: trading_career
+      70: has_command_block
+      71: command_block_command #string
+      72: command_block_last_output #string
+      73: command_block_track_output #byte
+      74: controlling_rider_seat_number #byte
+      75: strength #int
+      76: max_strength #int
+      77: spell_casting_color #int
+      78: limited_life
+      79: armor_stand_pose_index # int
+      80: ender_crystal_time_offset # int
+      81: always_show_nametag # byte
+      82: color_2 # byte
+      83: name_author
+      84: score_tag #String
+      85: balloon_attached_entity # long
+      86: pufferfish_size
+      87: bubble_time
+      88: agent
+      89: sitting_amount
+      90: sitting_amount_previous
+      91: eating_counter
+      92: flags_extended
+      93: laying_amount
+      94: laying_amount_previous
+      95: duration
+      96: spawn_time
+      97: change_rate
+      98: change_on_pickup
+      99: pickup_count
+      100: interact_text
+      101: trade_tier
+      102: max_trade_tier
+      103: trade_experience
+      104: skin_id
+      105: spawning_frames
+      106: command_block_tick_delay
+      107: command_block_execute_on_first_tick
+      108: ambient_sound_interval
+      109: ambient_sound_interval_range
+      110: ambient_sound_event_name
+      111: fall_damage_multiplier
+      112: name_raw_text
+      113: can_ride_target
+      114: low_tier_cured_discount
+      115: high_tier_cured_discount
+      116: nearby_cured_discount
+      117: nearby_cured_discount_timestamp
+      118: hitbox
+      119: is_buoyant
+      120: buoyancy_data
+      121: goat_horn_count
    type: varint =>
       0: byte
       1: short
@@ -245,16 +247,126 @@ MetadataDictionary: []varint
       6: vec3i
       7: long
       8: vec3f
-   value: type?
-      if byte: i8
-      if short: li16
-      if int: zigzag32
-      if float: lf32
-      if string: string
-      if compound: nbt
-      if vec3i: vec3i
-      if long: zigzag64
-      if vec3f: vec3f
+   value: key ?
+      if flags: MetadataFlags1
+      if flags_extended: MetadataFlags2
+      default: type ?
+         if byte: i8
+         if short: li16
+         if int: zigzag32
+         if float: lf32
+         if string: string
+         if compound: nbt
+         if vec3i: vec3i
+         if long: zigzag64
+         if vec3f: vec3f
+
+MetadataFlags1: [ "bitflags", {
+   "type": "zigzag64", "big": true, "shift": true,
+   "flags": {
+      "onfire": 0,
+      "sneaking": 1,
+      "riding": 2,
+      "sprinting": 3,
+      "action": 4,
+      "invisible": 5,
+      "tempted": 6,
+      "inlove": 7,
+      "saddled": 8,
+      "powered": 9,
+      "ignited": 10,
+      "baby": 11,
+      "converting": 12,
+      "critical": 13,
+      "can_show_nametag": 14,
+      "always_show_nametag": 15,
+      "no_ai": 16,
+      "silent": 17,
+      "wallclimbing": 18,
+      "can_climb": 19,
+      "swimmer": 20,
+      "can_fly": 21,
+      "walker": 22,
+      "resting": 23,
+      "sitting": 24,
+      "angry": 25,
+      "interested": 26,
+      "charged": 27,
+      "tamed": 28,
+      "orphaned": 29,
+      "leashed": 30,
+      "sheared": 31,
+      "gliding": 32,
+      "elder": 33,
+      "moving": 34,
+      "breathing": 35,
+      "chested": 36,
+      "stackable": 37,
+      "showbase": 38,
+      "rearing": 39,
+      "vibrating": 40,
+      "idling": 41,
+      "evoker_spell": 42,
+      "charge_attack": 43,
+      "wasd_controlled": 44,
+      "can_power_jump": 45,
+      "linger": 46,
+      "has_collision": 47,
+      "affected_by_gravity": 48,
+      "fire_immune": 49,
+      "dancing": 50,
+      "enchanted": 51,
+      "show_trident_rope": 52, # tridents show an animated rope when enchanted with loyalty after they are thrown and return to their owner. to be combined with data_owner_eid
+      "container_private": 53, #inventory is private, doesn't drop contents when killed if true
+      "transforming": 54,
+      "spin_attack": 55,
+      "swimming": 56,
+      "bribed": 57, #dolphins have this set when they go to find treasure for the player
+      "pregnant": 58,
+      "laying_egg": 59,
+      "rider_can_pick": 60, #???
+      "transition_sitting": 61,
+      "eating": 62,
+      "laying_down": 63,
+   }
+}]
+
+MetadataFlags2: [ "bitflags", {
+   "type": "zigzag64","big": true, "shift": true,
+   "flags": {
+      "sneezing": 64,
+      "trusting": 65,
+      "rolling": 66,
+      "scared": 67,
+      "in_scaffolding": 68,
+      "over_scaffolding": 69,
+      "fall_through_scaffolding": 70,
+      "blocking": 71, #shield
+      "transition_blocking": 72,
+      "blocked_using_shield": 73,
+      "blocked_using_damaged_shield": 74,
+      "sleeping": 75,
+      "wants_to_wake": 76,
+      "trade_interest": 77,
+      "door_breaker": 78, #...
+      "breaking_obstruction": 79,
+      "door_opener": 80, #...
+      "illager_captain": 81,
+      "stunned": 82,
+      "roaring": 83,
+      "delayed_attacking": 84,
+      "avoiding_mobs": 85,
+      "avoiding_block": 86,
+      "facing_target_to_range_attack": 87,
+      "hidden_when_invisible": 88, #??????????????????
+      "is_in_ui": 89,
+      "stalking": 90,
+      "emoting": 91,
+      "celebrating": 92,
+      "admiring": 93,
+      "celebrating_special": 94,
+   }
+}]
 
 Link:
    ridden_entity_id: zigzag64
@@ -632,29 +744,31 @@ ItemStackRequests: []varint
          # BeaconPaymentStackRequestAction is sent by the client when it submits an item to enable effects from a
          # beacon. These items will have been moved into the beacon item slot in advance. 
          8: beacon_payment
+         # MineBlockStackRequestAction is sent by the client when it breaks a block.
+         9: mine_block
          # CraftRecipeStackRequestAction is sent by the client the moment it begins crafting an item. This is the
          # first action sent, before the Consume and Create item stack request actions.
          # This action is also sent when an item is enchanted. Enchanting should be treated mostly the same way as
          # crafting, where the old item is consumed.
-         9: craft_recipe
+         10: craft_recipe
          # AutoCraftRecipeStackRequestAction is sent by the client similarly to the CraftRecipeStackRequestAction. The
          # only difference is that the recipe is automatically created and crafted by shift clicking the recipe book.
-         10: craft_recipe_auto  #recipe book?
+         11: craft_recipe_auto  #recipe book?
          # CraftCreativeStackRequestAction is sent by the client when it takes an item out fo the creative inventory.
          # The item is thus not really crafted, but instantly created.
-         11: craft_creative
+         12: craft_creative
          # CraftRecipeOptionalStackRequestAction is sent when using an anvil. When this action is sent, the
          # CustomNames field in the respective stack request is non-empty and contains the name of the item created
          # using the anvil.
-         12: optional
+         13: optional
          # CraftNonImplementedStackRequestAction is an action sent for inventory actions that aren't yet implemented
          # in the new system. These include, for example, anvils.
-         13: non_implemented  #anvils aren't fully implemented yet
+         14: non_implemented  #anvils aren't fully implemented yet
          # CraftResultsDeprecatedStackRequestAction is an additional, deprecated packet sent by the client after
          # crafting. It holds the final results and the amount of times the recipe was crafted. It shouldn't be used.
          # This action is also sent when an item is enchanted. Enchanting should be treated mostly the same way as
          # crafting, where the old item is consumed.
-         14: results_deprecated
+         15: results_deprecated
       _: type_id ?
          if take or place:
             count: u8
@@ -687,6 +801,15 @@ ItemStackRequests: []varint
             # PrimaryEffect and SecondaryEffect are the effects that were selected from the beacon.
             primary_effect: zigzag32
             secondary_effect: zigzag32
+         if mine_block:
+            # // Unknown1 ... TODO: Find out what this is for
+            unknown1: zigzag32
+            # PredictedDurability is the durability of the item that the client assumes to be present at the time
+            predicted_durability: zigzag32
+            # StackNetworkID is the unique stack ID that the client assumes to be present at the time. The server
+            # must check if these IDs match. If they do not match, servers should reject the stack request that the
+            # action holding this info was in.
+            network_id: zigzag32 
          if craft_recipe or craft_recipe_auto:
             # RecipeNetworkID is the network ID of the recipe that is about to be crafted. This network ID matches
             # one of the recipes sent in the CraftingData packet, where each of the recipes have a RecipeNetworkID as
@@ -710,17 +833,43 @@ ItemStackRequests: []varint
    # * Used for the server to determine which strings should be filtered. Used in anvils to verify a renamed item.
    custom_names: string[]varint
 
+# ItemStackResponse is a response to an individual ItemStackRequest.
 ItemStackResponses: []varint
-   result: u8
+	# Status specifies if the request with the RequestID below was successful. If this is the case, the
+	# ContainerInfo below will have information on what slots ended up changing. If not, the container info
+	# will be empty.
+	# A non-0 status means an error occurred and will result in the action being reverted.
+   status: u8 =>
+      0: ok
+      1: error
+   # RequestID is the unique ID of the request that this response is in reaction to. If rejected, the client
+   # will undo the actions from the request with this ID.
    request_id: varint32
+   # ContainerInfo holds information on the containers that had their contents changed as a result of the
+   # request.
    containers: []varint
-      container_id: u8
+      # ContainerID is the container ID of the container that the slots that follow are in. For the main
+      # inventory, this value seems to be 0x1b. For the cursor, this value seems to be 0x3a. For the crafting
+      # grid, this value seems to be 0x0d.
+      # * actually, this is ContainerSlotType - used by the inventory system that specifies the type of slot
+      slot_type: ContainerSlotType
+      # SlotInfo holds information on what item stack should be present in specific slots in the container.
       slots: []varint
+         # Slot and HotbarSlot seem to be the same value every time: The slot that was actually changed. I'm not
+         # sure if these slots ever differ.
          slot: u8
          hotbar_slot: u8
+         # Count is the total count of the item stack. This count will be shown client-side after the response is
+         # sent to the client.
          count: u8
+         # StackNetworkID is the network ID of the new stack at a specific slot.
          item_stack_id: varint32
+         # CustomName is the custom name of the item stack. It is used in relation to text filtering.
          custom_name: string
+         # DurabilityCorrection is the current durability of the item stack. This durability will be shown
+         # client-side after the response is sent to the client.
+         durability_correction: zigzag32
+
 
 ItemComponentList: []varint
    # Name is the name of the item, which is a name like 'minecraft:stick'.
@@ -826,6 +975,68 @@ WindowType: u8 =>
    31: hud
    32: jigsaw_editor
    33: smithing_table
+
+ContainerSlotType: u8 =>
+   - anvil_input
+   - anvil_material
+   - anvil_result
+   - smithing_table_input
+   - smithing_table_material
+   - smithing_table_result
+   - armor
+   - container
+   - beacon_payment
+   - brewing_input
+   - brewing_result
+   - brewing_fuel
+   - hotbar_and_inventory
+   - crafting_input
+   - crafting_output
+   - recipe_construction
+   - recipe_nature
+   - recipe_items
+   - recipe_search
+   - recipe_search_bar
+   - recipe_equipment
+   - enchanting_input
+   - enchanting_lapis
+   - furnace_fuel
+   - furnace_ingredient
+   - furnace_output
+   - horse_equip
+   - hotbar
+   - inventory
+   - shulker
+   - trade_ingredient1
+   - trade_ingredient2
+   - trade_result
+   - offhand
+   - compcreate_input
+   - compcreate_output
+   - elemconstruct_output
+   - matreduce_input
+   - matreduce_output
+   - labtable_input
+   - loom_input
+   - loom_dye
+   - loom_material
+   - loom_result
+   - blast_furnace_ingredient
+   - smoker_ingredient
+   - trade2_ingredient1
+   - trade2_ingredient2
+   - trade2_result
+   - grindstone_input
+   - grindstone_additional
+   - grindstone_result
+   - stonecutter_input
+   - stonecutter_result
+   - cartography_input
+   - cartography_additional
+   - cartography_result
+   - barrel
+   - cursor
+   - creative_output
 
 # TODO: remove?
 LegacyEntityType: li32 =>

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "babel-eslint": "^10.1.0",
     "buffer-equal": "^1.0.0",
     "mocha": "^8.3.2",
-    "protodef-yaml": "^1.0.1",
+    "protodef-yaml": "^1.0.2",
     "standard": "^16.0.3"
   },
   "standard": {

--- a/src/auth/login.js
+++ b/src/auth/login.js
@@ -59,6 +59,10 @@ module.exports = (client, server, options) => {
       PieceTintColors: [],
       PlatformOfflineId: '',
       PlatformOnlineId: '', // chat
+      // PlayFabID is the PlayFab ID produced for the skin. PlayFab is the company that hosts the Marketplace,
+      // skins and other related features from the game. This ID is the ID of the skin used to store the skin
+      // inside of PlayFab.
+      PlayFabId: '5eb65f73-af11-448e-82aa-1b7b165316ad.persona-e199672a8c1a87e0-0', // 1.16.210
       PremiumSkin: false,
       SelfSignedId: '78eb38a6-950e-3ab9-b2cf-dd849e343701',
       ServerAddress: `${options.hostname}:${options.port}`,

--- a/src/options.js
+++ b/src/options.js
@@ -3,6 +3,11 @@ const MIN_VERSION = '1.16.201'
 // Currently supported verson
 const CURRENT_VERSION = '1.16.210'
 
+const Versions = {
+  '1.16.210': 428,
+  '1.16.201': 422
+}
+
 const defaultOptions = {
   // https://minecraft.gamepedia.com/Protocol_version#Bedrock_Edition_2
   version: CURRENT_VERSION,
@@ -12,11 +17,6 @@ const defaultOptions = {
   autoInitPlayer: true,
   // If true, do not authenticate with Xbox Live
   offline: false
-}
-
-const Versions = {
-  '1.16.210': 428,
-  '1.16.201': 422
 }
 
 module.exports = { defaultOptions, MIN_VERSION, CURRENT_VERSION, Versions }

--- a/src/options.js
+++ b/src/options.js
@@ -1,7 +1,7 @@
 // Minimum supported version (< will be kicked)
 const MIN_VERSION = '1.16.201'
 // Currently supported verson
-const CURRENT_VERSION = '1.16.201'
+const CURRENT_VERSION = '1.16.210'
 
 const defaultOptions = {
   // https://minecraft.gamepedia.com/Protocol_version#Bedrock_Edition_2
@@ -15,8 +15,7 @@ const defaultOptions = {
 }
 
 const Versions = {
-  // TODO
-  // '1.16.210': 428,
+  '1.16.210': 428,
   '1.16.201': 422
 }
 

--- a/src/transforms/serializer.js
+++ b/src/transforms/serializer.js
@@ -1,12 +1,13 @@
 const { ProtoDefCompiler, CompiledProtodef } = require('protodef').Compiler
 const { FullPacketParser, Serializer } = require('protodef')
+const { join } = require('path')
 
 // Compiles the ProtoDef schema at runtime
 function createProtocol (version) {
-  const protocol = require(`../../data/${version}/protocol.json`).types
+  const protocol = require(join(__dirname, `../../data/${version}/protocol.json`)).types
   const compiler = new ProtoDefCompiler()
   compiler.addTypesToCompile(protocol)
-  compiler.addTypes(require('../datatypes/compiler-minecraft'))
+  compiler.addTypes(require(join(__dirname, '../datatypes/compiler-minecraft')))
   compiler.addTypes(require('prismarine-nbt/compiler-zigzag'))
 
   const compiledProto = compiler.compileProtoDefSync()
@@ -16,7 +17,7 @@ function createProtocol (version) {
 // Loads already generated read/write/sizeof code
 function getProtocol (version) {
   const compiler = new ProtoDefCompiler()
-  compiler.addTypes(require('../datatypes/compiler-minecraft'))
+  compiler.addTypes(require(join(__dirname, '../datatypes/compiler-minecraft')))
   compiler.addTypes(require('prismarine-nbt/compiler-zigzag'))
 
   const compile = (compiler, file) => {
@@ -26,9 +27,9 @@ function getProtocol (version) {
   }
 
   return new CompiledProtodef(
-    compile(compiler.sizeOfCompiler, `../../data/${version}/size.js`),
-    compile(compiler.writeCompiler, `../../data/${version}/write.js`),
-    compile(compiler.readCompiler, `../../data/${version}/read.js`)
+    compile(compiler.sizeOfCompiler, join(__dirname, `../../data/${version}/size.js`)),
+    compile(compiler.writeCompiler, join(__dirname, `../../data/${version}/write.js`)),
+    compile(compiler.readCompiler, join(__dirname, `../../data/${version}/read.js`))
   )
 }
 

--- a/test/vanilla.js
+++ b/test/vanilla.js
@@ -3,9 +3,9 @@ const vanillaServer = require('../tools/startVanillaServer')
 const { Client } = require('../src/client')
 const { waitFor } = require('../src/datatypes/util')
 
-async function test () {
+async function test (version) {
   // Start the server, wait for it to accept clients, throws on timeout
-  const handle = await vanillaServer.startServerAndWait('1.16.201', 1000 * 120)
+  const handle = await vanillaServer.startServerAndWait(version, 1000 * 120)
   console.log('Started server')
 
   const client = new Client({

--- a/test/vanilla.js
+++ b/test/vanilla.js
@@ -12,6 +12,7 @@ async function test (version) {
     hostname: '127.0.0.1',
     port: 19130,
     username: 'Notch',
+    version,
     offline: true
   })
 

--- a/test/vanilla.test.js
+++ b/test/vanilla.test.js
@@ -3,11 +3,12 @@
 const { clientTest } = require('./vanilla')
 const { Versions } = require('../src/options')
 
-describe('vanilla server test', function () {
+describe ('vanilla server test', function () {
   this.timeout(120 * 1000)
-  it('client spawns', async () => {
-    for (const version in Versions) {
-      await clientTest(version) 
-    }
-  })
+
+  for (const version in Versions) {
+    it('client spawns ' + version, async () => {
+      await clientTest(version)
+    })
+  }
 })

--- a/test/vanilla.test.js
+++ b/test/vanilla.test.js
@@ -1,10 +1,13 @@
 /* eslint-env jest */
 
 const { clientTest } = require('./vanilla')
+const { Versions } = require('../src/options')
 
 describe('vanilla server test', function () {
   this.timeout(120 * 1000)
   it('client spawns', async () => {
-    await clientTest()
+    for (const version in Versions) {
+      await clientTest(version) 
+    }
   })
 })


### PR DESCRIPTION
* adds support for 1.16.210
* adds new options to `bitflags` type to auto-increment shift position (e.g. `1<<n++`) and support 64-bit numbers with bigint
* switch require paths to absolute when loading protocol, generate js for all versions