### PR TITLE
Fix microsoft auth refresh

### DIFF
--- a/src/client/tokens.js
+++ b/src/client/tokens.js
@@ -103,9 +103,10 @@ class MsaTokenManager {
   }
 
   async verifyTokens () {
+    if (this.forceRefresh) try { await this.refreshTokens() } catch {}
     const at = this.getAccessToken()
     const rt = this.getRefreshToken()
-    if (!at || !rt || this.forceRefresh) {
+    if (!at || !rt) {
       return false
     }
     debug('[msa] have at, rt', at, rt)

--- a/test/internal.test.js
+++ b/test/internal.test.js
@@ -5,7 +5,7 @@ const { proxyTest } = require('./proxy')
 const { Versions } = require('../src/options')
 
 describe('internal client/server test', function () {
-  this.timeout(220 * 1000)
+  this.timeout(240 * 1000)
 
   for (const version in Versions) {
     it('connects ' + version, async () => {

--- a/test/proxy.js
+++ b/test/proxy.js
@@ -1,7 +1,7 @@
 const { createClient, createServer, Relay } = require('bedrock-protocol')
 const { sleep, waitFor } = require('../src/datatypes/util')
 
-function proxyTest (version, timeout = 1000 * 20) {
+function proxyTest (version, timeout = 1000 * 40) {
   return waitFor(res => {
     const server = createServer({
       host: '0.0.0.0', // optional


### PR DESCRIPTION
Minor fix for ms auth, refresh before getting access/refresh token if `forceRefresh` was requested (auth failed prior due to expired cache)