### PR TITLE
Fix empty chunks on proxy spawn

### DIFF
--- a/data/latest/proto.yml
+++ b/data/latest/proto.yml
@@ -923,7 +923,15 @@ packet_set_spawn_position:
 packet_animate:
    !id: 0x2c
    !bound: both
-   action_id: zigzag32
+   action_id: zigzag32 =>
+      0: none
+      1: swing_arm
+      2: unknown
+      3: wake_up
+      4: critical_hit
+      5: magic_critical_hit
+      6: row_right
+      7: row_left
    runtime_entity_id: varint64
 
 packet_respawn:

--- a/src/relay.js
+++ b/src/relay.js
@@ -62,14 +62,14 @@ class RelayPlayer extends Player {
       }
       if (name === 'respawn') this.respawnPacket.push([name, params])
     } else if (this.status === 3 && this.chunkSendCache.length) {
-        for (const chunk of this.chunkSendCache) {
-          this.queue(...chunk)
-        }
-        for (const rp of this.respawnPacket) {
-          this.queue(...rp)
-        }
-        this.chunkSendCache = []
-        this.respawnPacket = []
+      for (const chunk of this.chunkSendCache) {
+        this.queue(...chunk)
+      }
+      for (const rp of this.respawnPacket) {
+        this.queue(...rp)
+      }
+      this.chunkSendCache = []
+      this.respawnPacket = []
     }
     this.queue(name, params)
   }


### PR DESCRIPTION
Hack to fix issue with chunks not loading when client joins the proxy
* Queue chunk, respawn packets and only send them after player spawn

Need to investigate why this is an issue later.