### PR TITLE
Release 3.3.0

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,7 @@
+## 3.3.0
+* Protocol updates for 1.16, with some minor breaking changes to protocol fields [#95](https://github.com/PrismarineJS/bedrock-protocol/pull/95)
+* Fix npm install issues
+
 ## 3.2.1
 * Add `authTitle` option to Relay proxy [#92](https://github.com/PrismarineJS/bedrock-protocol/pull/92)
 * Protocol, type definition fixes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bedrock-protocol",
-  "version": "3.2.2",
+  "version": "3.3.0",
   "description": "Minecraft Bedrock Edition protocol library",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bedrock-protocol",
-  "version": "3.2.1",
+  "version": "3.2.2",
   "description": "Minecraft Bedrock Edition protocol library",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
* Protocol updates for 1.16, with some minor breaking changes to protocol fields [#95](https://github.com/PrismarineJS/bedrock-protocol/pull/95)
* Temporary fix npm install issues