### PR TITLE
fix: type definition errors found related to ServerAdvertisements.

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -36,7 +36,7 @@ authenticated unless offline is set to true.
 | maxPlayers | *optional* | default to **3**. Set this to change the maximum number of players connected.   |
 | kickTimeout | *[Future][1]* | How long to wait before kicking a unresponsive client. |
 | motd        | *optional* | The "message of the day" for the server, the message shown to players in the server list. See usage below. |
-| advertismentFn | *optional* | optional. Custom function to call that should return a ServerAdvertisement, used for setting the RakNet server PONG data. Overrides `motd`. |
+| advertisementFn | *optional* | optional. Custom function to call that should return a ServerAdvertisement, used for setting the RakNet server PONG data. Overrides `motd`. |
 
 ## be.ping({ host, port }) : ServerAdvertisement
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -17,7 +17,8 @@ Returns a `Client` instance and connects to the server.
 | connectTimeout | *optional* | default to **9000ms**. How long to wait in milliseconds while trying to connect to server. |
 | onMsaCode   | *optional* |  Callback called when signing in with a microsoft account with device code auth, `data` is an object documented [here](https://docs.microsoft.com/en-us/azure/active-directory/develop/v2-oauth2-device-code#device-authorization-response) |
 | profilesFolder | *optional* | Where to store cached authentication tokens. Defaults to .minecraft, or the node_modules folder if not found. |
-| autoInitPlayer | optional |  default to true, If we should send SetPlayerInitialized to the server after getting play_status spawn.    |
+| autoInitPlayer | *optional* |  default to true, If we should send SetPlayerInitialized to the server after getting play_status spawn.    |
+| skipPing | *optional* | Whether pinging the server to check its version should be skipped. |
 
 
 ## be.createServer(options) : Server

--- a/index.d.ts
+++ b/index.d.ts
@@ -145,10 +145,8 @@ declare module "bedrock-protocol" {
     name: string
     protocol: number
     version: string
-    players: {
-      online: number,
-      max: number
-    }
+    playersOnline: number
+    playersMax: number
     gamemode: string
     serverId: string
   }

--- a/index.d.ts
+++ b/index.d.ts
@@ -23,6 +23,8 @@ declare module "bedrock-protocol" {
     viewDistance?: number,
     // Specifies which game edition to sign in as. Optional, but some servers verify this.
     authTitle?: title | string,
+    // How long to wait in milliseconds while trying to connect to the server.
+    connectTimeout?: number
     // whether to skip initial ping and immediately connect
     skipPing?: boolean
   }

--- a/index.d.ts
+++ b/index.d.ts
@@ -36,6 +36,7 @@ declare module "bedrock-protocol" {
       // The sub-header for the MOTD shown in the server list.
       levelName: string
     }
+    advertisementFn: () => ServerAdvertisement
   }
 
   enum ClientStatus {


### PR DESCRIPTION
Fixes the definition of where the online/max player counts are.

(Sorry for another type definition fix. 🌵)