### PR TITLE
Option to use JS implementation of RakNet, fix 1.17.10 issue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,8 @@ jobs:
     strategy:
       matrix:
         node-version: [14.x]
-
+    env:
+      FORCE_BUILD: true
     steps:
     - uses: actions/checkout@v2
     - name: Use Node.js ${{ matrix.node-version }}

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,7 @@
+## 3.5.0
+* Add 1.17.10 support [#109](https://github.com/PrismarineJS/bedrock-protocol/pull/109)
+* JS implementation of RakNet is now the default. This may cause issues. You can revert to the native implementation by setting `useNativeRaknet: true`.
+
 ## 3.4.0
 * Initial 1.17 support [#99](https://github.com/PrismarineJS/bedrock-protocol/pull/99)
 * update connect version based on ping response & fix typings (u9g) [#101](https://github.com/PrismarineJS/bedrock-protocol/pull/101)

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,6 @@
 ## 3.5.0
 * Add 1.17.10 support [#109](https://github.com/PrismarineJS/bedrock-protocol/pull/109)
-* JS implementation of RakNet is now the default. This may cause issues. You can revert to the native implementation by setting `useNativeRaknet: true`.
+* You can switch to the JS implementation of raknet by setting `useNativeRaknet: false` in options.
 
 ## 3.4.0
 * Initial 1.17 support [#99](https://github.com/PrismarineJS/bedrock-protocol/pull/99)

--- a/data/1.17.10/protocol.json
+++ b/data/1.17.10/protocol.json
@@ -3781,16 +3781,16 @@
           "type": "bool"
         },
         {
+          "name": "force_server_packs",
+          "type": "bool"
+        },
+        {
           "name": "behaviour_packs",
           "type": "BehaviourPackInfos"
         },
         {
           "name": "texture_packs",
           "type": "TexturePackInfos"
-        },
-        {
-          "name": "force_server_packs",
-          "type": "bool"
         }
       ]
     ],

--- a/data/latest/proto.yml
+++ b/data/latest/proto.yml
@@ -120,14 +120,14 @@ packet_resource_packs_info:
    must_accept: bool
    # If scripting is enabled.
    has_scripts: bool
+   # ForcingServerPacks is currently an unclear field.
+   force_server_packs: bool
    # A list of behaviour packs that the client needs to download before joining the server. 
    # All of these behaviour packs will be applied together.
    behaviour_packs: BehaviourPackInfos
    # A list of resource packs that the client needs to download before joining the server. 
    # The order of these resource packs is not relevant in this packet. It is however important in the Resource Pack Stack packet.
    texture_packs: TexturePackInfos
-   # ForcingServerPacks is currently an unclear field.
-   force_server_packs: bool
 
 packet_resource_pack_stack:
    !id: 0x07

--- a/docs/API.md
+++ b/docs/API.md
@@ -19,7 +19,7 @@ Returns a `Client` instance and connects to the server.
 | profilesFolder | *optional* | Where to store cached authentication tokens. Defaults to .minecraft, or the node_modules folder if not found. |
 | autoInitPlayer | *optional* |  default to true, If we should send SetPlayerInitialized to the server after getting play_status spawn.    |
 | skipPing | *optional* | Whether pinging the server to check its version should be skipped. |
-
+| useNativeRaknet | *optional* | Whether to use the C++ version of RakNet. Set to false to use JS. |
 
 ## be.createServer(options) : Server
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -15,7 +15,12 @@ declare module "bedrock-protocol" {
     port?: number
     // For the client, if we should login with Microsoft/Xbox Live.
     // For the server, if we should verify client's authentication with Xbox Live.
-    offline?: boolean
+    offline?: boolean,
+
+    // Whether or not to use C++ version of RakNet (default: false)
+    useNativeRaknet?: boolean,
+    // If using JS implementation of RakNet, should we use workers? (This only affects the client)
+    useRaknetWorker?: boolean
   }
 
   export interface ClientOptions extends Options {

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,7 +1,7 @@
 import EventEmitter from "events"
 
 declare module "bedrock-protocol" {
-  type Version = '1.17.0' | '1.16.220' | '1.16.210' | '1.16.201'
+  type Version = '1.17.10' | '1.17.0' | '1.16.220' | '1.16.210' | '1.16.201'
 
   enum title { MinecraftNintendoSwitch, MinecraftJava }
 
@@ -17,7 +17,7 @@ declare module "bedrock-protocol" {
     // For the server, if we should verify client's authentication with Xbox Live.
     offline?: boolean,
 
-    // Whether or not to use C++ version of RakNet (default: false)
+    // Whether or not to use C++ version of RakNet
     useNativeRaknet?: boolean,
     // If using JS implementation of RakNet, should we use workers? (This only affects the client)
     useRaknetWorker?: boolean

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "debug": "^4.3.1",
     "jose-node-cjs-runtime": "^3.12.1",
     "jsonwebtoken": "^8.5.1",
-    "jsp-raknet": "^2.1.0",
+    "jsp-raknet": "^2.1.1",
     "minecraft-folder-path": "^1.1.0",
     "node-fetch": "^2.6.1",
     "prismarine-nbt": "^1.5.0",
@@ -34,7 +34,7 @@
     "smart-buffer": "^4.1.0",
     "uuid-1345": "^1.0.2"
   },
-  "optionalDependencies": {
+  "peerDependencies": {
     "raknet-native": "^1.0.3"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "debug": "^4.3.1",
     "jose-node-cjs-runtime": "^3.12.1",
     "jsonwebtoken": "^8.5.1",
-    "jsp-raknet": "^2.1.1",
+    "jsp-raknet": "^2.1.3",
     "minecraft-folder-path": "^1.1.0",
     "node-fetch": "^2.6.1",
     "prismarine-nbt": "^1.5.0",
@@ -34,7 +34,7 @@
     "smart-buffer": "^4.1.0",
     "uuid-1345": "^1.0.2"
   },
-  "peerDependencies": {
+  "optionalDependencies": {
     "raknet-native": "^1.0.3"
   },
   "devDependencies": {

--- a/src/client.js
+++ b/src/client.js
@@ -1,6 +1,5 @@
 const { ClientStatus, Connection } = require('./connection')
 const { createDeserializer, createSerializer } = require('./transforms/serializer')
-const { RakClient } = require('./rak')
 const { serialize, isDebug } = require('./datatypes/util')
 const debug = require('debug')('minecraft-protocol')
 const Options = require('./options')
@@ -21,6 +20,11 @@ class Client extends Connection {
     super()
     this.options = { ...Options.defaultOptions, ...options }
     this.validateOptions()
+
+    if (this.options.useNativeRaknet) process.env.NATIVE_RAKNET = true
+
+    const { RakClient } = require('./rak')
+
     this.serializer = createSerializer(this.options.version)
     this.deserializer = createDeserializer(this.options.version)
 
@@ -30,7 +34,7 @@ class Client extends Connection {
 
     const host = this.options.host
     const port = this.options.port
-    this.connection = new RakClient({ useWorkers: true, host, port })
+    this.connection = new RakClient({ useWorkers: this.options.useRaknetWorkers, host, port })
 
     this.startGameData = {}
     this.clientRuntimeId = null

--- a/src/client.js
+++ b/src/client.js
@@ -21,9 +21,7 @@ class Client extends Connection {
     this.options = { ...Options.defaultOptions, ...options }
     this.validateOptions()
 
-    if (this.options.useNativeRaknet) process.env.NATIVE_RAKNET = true
-
-    const { RakClient } = require('./rak')
+    const { RakClient } = require('./rak')(this.options.useNativeRaknet)
 
     this.serializer = createSerializer(this.options.version)
     this.deserializer = createDeserializer(this.options.version)

--- a/src/createClient.js
+++ b/src/createClient.js
@@ -1,5 +1,5 @@
 const { Client } = require('./client')
-const { RakClient } = require('./rak')
+const { RakClient } = require('./rak')(true)
 const assert = require('assert')
 const advertisement = require('./server/advertisement')
 const { sleep } = require('./datatypes/util')

--- a/src/options.js
+++ b/src/options.js
@@ -21,7 +21,11 @@ const defaultOptions = {
   // If true, do not authenticate with Xbox Live
   offline: false,
   // Milliseconds to wait before aborting connection attempt
-  connectTimeout: 9000
+  connectTimeout: 9000,
+  // Whether or not to use C++ version of RakNet
+  useNativeRaknet: false,
+  // If using JS implementation of RakNet, should we use workers? (This only affects the client)
+  useRaknetWorkers: true
 }
 
 module.exports = { defaultOptions, MIN_VERSION, CURRENT_VERSION, Versions }

--- a/src/options.js
+++ b/src/options.js
@@ -23,7 +23,7 @@ const defaultOptions = {
   // Milliseconds to wait before aborting connection attempt
   connectTimeout: 9000,
   // Whether or not to use C++ version of RakNet
-  useNativeRaknet: false,
+  useNativeRaknet: true,
   // If using JS implementation of RakNet, should we use workers? (This only affects the client)
   useRaknetWorkers: true
 }

--- a/src/rak.js
+++ b/src/rak.js
@@ -2,11 +2,17 @@ const { EventEmitter } = require('events')
 const ConnWorker = require('./rakWorker')
 const { waitFor } = require('./datatypes/util')
 // TODO: better way to switch, via an option
-try {
-  var { Client, Server, PacketPriority, PacketReliability } = require('raknet-native') // eslint-disable-line
-} catch (e) {
+
+if (process.env.NATIVE_RAKNET) {
+  try {
+    var { Client, Server, PacketPriority, PacketReliability } = require('raknet-native') // eslint-disable-line
+  } catch (e) {
+    var { Client, Server, EncapsulatedPacket, Reliability } = require('jsp-raknet') // eslint-disable-line
+    console.debug('[raknet] native not found, using js', e)
+    console.debug('You can suppress the error above by disabling `useNativeRaknet` in your options')
+  }
+} else {
   var { Client, Server, EncapsulatedPacket, Reliability } = require('jsp-raknet') // eslint-disable-line
-  console.debug('[raknet] native not found, using js', e)
 }
 
 class RakNativeClient extends EventEmitter {
@@ -118,9 +124,10 @@ class RakJsClient extends EventEmitter {
       this.sendReliable = this.workerSendReliable
     } else {
       this.connect = this.plainConnect
-      this.close = this.plainClose
+      this.close = reason => this.raknet.close(reason)
       this.sendReliable = this.plainSendReliable
     }
+    this.pongCb = null
   }
 
   workerConnect (host = this.options.host, port = this.options.port) {
@@ -137,6 +144,8 @@ class RakJsClient extends EventEmitter {
           this.onEncapsulated(ecapsulated, address.hash)
           break
         }
+        case 'pong':
+          this.pongCb?.(evt.args)
       }
     })
   }
@@ -165,12 +174,21 @@ class RakJsClient extends EventEmitter {
     if (immediate) this.connection.sendQueue()
   }
 
-  plainClose (reason) {
-    this.raknet.close(reason)
-  }
-
-  ping () {
-    // TODO
+  async ping (timeout = 1000) {
+    if (this.worker) {
+      this.worker.postMessage({ type: 'ping' })
+      return waitFor(res => {
+        this.pongCb = data => res(data)
+      }, timeout, () => { throw new Error('Ping timed out') })
+    } else {
+      if (!this.raknet) this.raknet = new Client(this.options.host, this.options.port)
+      return waitFor(res => {
+        this.raknet.ping(data => {
+          this.raknet.close()
+          res(data)
+        })
+      }, timeout, () => { throw new Error('Ping timed out') })
+    }
   }
 }
 
@@ -206,6 +224,13 @@ class RakJsServer extends EventEmitter {
     })
     this.raknet.on('closeConnection', this.onCloseConnection)
     this.raknet.on('encapsulated', this.onEncapsulated)
+  }
+
+  close () {
+    // Allow some time for the final packets to come in/out
+    setTimeout(() => {
+      this.raknet.close()
+    }, 40)
   }
 }
 

--- a/src/rakWorker.js
+++ b/src/rakWorker.js
@@ -53,6 +53,11 @@ function main () {
       }
     } else if (evt.type === 'close') {
       raknet.close()
+      process.exit(0)
+    } else if (evt.type === 'ping') {
+      raknet.ping((args) => {
+        parentPort.postMessage({ type: 'pong', args })
+      })
     }
   })
 }

--- a/src/server.js
+++ b/src/server.js
@@ -1,7 +1,6 @@
 const { EventEmitter } = require('events')
 const { createDeserializer, createSerializer } = require('./transforms/serializer')
 const { Player } = require('./serverPlayer')
-const { RakServer } = require('./rak')
 const { sleep } = require('./datatypes/util')
 const { ServerAdvertisement } = require('./server/advertisement')
 const Options = require('./options')
@@ -12,6 +11,10 @@ class Server extends EventEmitter {
     super()
     this.options = { ...Options.defaultOptions, ...options }
     this.validateOptions()
+
+    if (this.options.useNativeRaknet) process.env.NATIVE_RAKNET = true
+    this.RakServer = require('./rak').RakServer
+
     this.serializer = createSerializer(this.options.version)
     this.deserializer = createDeserializer(this.options.version)
     this.advertisement = new ServerAdvertisement(this.options.motd)
@@ -66,7 +69,7 @@ class Server extends EventEmitter {
   }
 
   async listen (host = this.options.host, port = this.options.port) {
-    this.raknet = new RakServer({ host, port }, this)
+    this.raknet = new this.RakServer({ host, port }, this)
     try {
       await this.raknet.listen()
     } catch (e) {

--- a/src/server.js
+++ b/src/server.js
@@ -12,8 +12,7 @@ class Server extends EventEmitter {
     this.options = { ...Options.defaultOptions, ...options }
     this.validateOptions()
 
-    if (this.options.useNativeRaknet) process.env.NATIVE_RAKNET = true
-    this.RakServer = require('./rak').RakServer
+    this.RakServer = require('./rak')(this.options.useNativeRaknet).RakServer
 
     this.serializer = createSerializer(this.options.version)
     this.deserializer = createDeserializer(this.options.version)

--- a/test/internal.js
+++ b/test/internal.js
@@ -196,7 +196,7 @@ async function requestChunks (x, z, radius) {
   return chunks
 }
 
-async function timedTest (version, timeout = 1000 * 120) {
+async function timedTest (version, timeout = 1000 * 220) {
   await waitFor((res) => {
     startTest(version, res)
   }, timeout, () => {

--- a/test/internal.test.js
+++ b/test/internal.test.js
@@ -5,7 +5,8 @@ const { proxyTest } = require('./proxy')
 const { Versions } = require('../src/options')
 
 describe('internal client/server test', function () {
-  this.timeout(240 * 1000)
+  const vcount = Object.keys(Versions).length
+  this.timeout(vcount * 80 * 1000)
 
   for (const version in Versions) {
     it('connects ' + version, async () => {

--- a/test/vanilla.test.js
+++ b/test/vanilla.test.js
@@ -4,7 +4,8 @@ const { clientTest } = require('./vanilla')
 const { Versions } = require('../src/options')
 
 describe('vanilla server test', function () {
-  this.timeout(220 * 1000)
+  const vcount = Object.keys(Versions).length
+  this.timeout(vcount * 80 * 1000)
 
   for (const version in Versions) {
     it('client spawns ' + version, async () => {

--- a/tools/startVanillaServer.js
+++ b/tools/startVanillaServer.js
@@ -82,6 +82,10 @@ async function startServer (version, onStart, options = {}) {
   await download(os, version, options.path)
   configure(options)
   const handle = run(!onStart)
+  handle.on('error', (...a) => {
+    console.warn('*** THE MINECRAFT PROCESS CRASHED ***', a)
+    handle.kill('SIGKILL')
+  })
   if (onStart) {
     let stdout = ''
     handle.stdout.on('data', data => {


### PR DESCRIPTION
~~Default to JS/worker implementation of RakNet. May cause issues and bugs at first, but this also means faster install times and hopefully less native-related issues.~~

* Adds option to use JS implementation of RakNet with `useNativeRaknet: false` in options.
* Fix 1.17.10 texture pack issue