### PR TITLE
Update prismarine-auth usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,9 +46,7 @@ const client = bedrock.createClient({
   host: 'localhost',   // optional
   port: 19132,         // optional, default 19132
   username: 'Notch',   // the username you want to join as, optional if online mode
-  offline: true,       // optional, default false. if true, do not login with Xbox Live. You will not be asked to sign-in if set to true.
-  // Optional for some servers which verify the title ID:
-  // authTitle: bedrock.title.MinecraftNintendoSwitch
+  offline: true       // optional, default false. if true, do not login with Xbox Live. You will not be asked to sign-in if set to true.
 })
 
 client.on('text', (packet) => { // Listen for chat messages and echo them back.

--- a/docs/API.md
+++ b/docs/API.md
@@ -20,6 +20,8 @@ Returns a `Client` instance and connects to the server.
 | autoInitPlayer | *optional* |  default to true, If we should send SetPlayerInitialized to the server after getting play_status spawn.    |
 | skipPing | *optional* | Whether pinging the server to check its version should be skipped. |
 | useNativeRaknet | *optional* | Whether to use the C++ version of RakNet. Set to false to use JS. |
+| authTitle | *optional* | The client ID to sign in as, defaults to Minecraft for Nintendo Switch. Set false to sign in through Azure. See prismarine-auth |
+| deviceType | *optional* | The device type to sign in as, defaults to "Nintendo". See prismarine-auth |
 
 ## be.createServer(options) : Server
 

--- a/examples/client/client.js
+++ b/examples/client/client.js
@@ -4,9 +4,7 @@ const client = bedrock.createClient({
   host: 'localhost',   // optional
   port: 19132,         // optional, default 19132
   username: 'Notch',   // the username you want to join as, optional if online mode
-  offline: false,      // optional, default false. if true, do not login with Xbox Live. You will not be asked to sign-in if set to true.
-  // Optional for some servers which verify the title ID:
-  // authTitle: bedrock.title.MinecraftNintendoSwitch
+  offline: false      // optional, default false. if true, do not login with Xbox Live. You will not be asked to sign-in if set to true.
 })
 
 client.on('text', (packet) => { // Listen for chat messages and echo them back.

--- a/examples/createRelay.js
+++ b/examples/createRelay.js
@@ -1,4 +1,4 @@
-const { Relay, title } = require('bedrock-protocol')
+const { Relay } = require('bedrock-protocol')
 
 function createRelay () {
   console.log('Creating relay')
@@ -8,7 +8,6 @@ function createRelay () {
     host: '0.0.0.0',
     port: 19130,
     offline: false,
-    authTitle: title.MinecraftNintendoSwitch,
     /* Where to send upstream packets to */
     destination: {
       host: '127.0.0.1',

--- a/src/client/auth.js
+++ b/src/client/auth.js
@@ -16,12 +16,16 @@ async function authenticate (client, options) {
   if (!options.profilesFolder) {
     options.profilesFolder = path.join(minecraftFolderPath, 'nmp-cache')
   }
-  if (!options.authTitle) {
+  if (options.authTitle === undefined) {
     options.authTitle = Titles.MinecraftNintendoSwitch
+    options.deviceType = 'Nintendo'
   }
   try {
     const Authflow = new PrismarineAuth(options.username, options.profilesFolder, options, options.onMsaCode)
-    const chains = await Authflow.getMinecraftBedrockToken(client.clientX509)
+    const chains = await Authflow.getMinecraftBedrockToken(client.clientX509).catch(e => {
+      if (options.password) console.warn('Sign in failed, try removing the password field')
+      throw e
+    })
 
     debug('chains', chains)
 


### PR DESCRIPTION
* update for https://github.com/PrismarineJS/prismarine-auth/pull/21
* Remove unnecessary docs on `authTitle`, it's now always set to Nintendo Switch (set to false=use msal and no title visible to servers)