### PR TITLE
1.18 update

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Minecraft Bedrock Edition (aka MCPE) protocol library, supporting authentication
 
 ## Features
 
- - Supports Minecraft Bedrock version 1.16.201, 1.16.210, 1.16.220, 1.17.0, 1.17.10, 1.17.30, 1.17.40
+ - Supports Minecraft Bedrock version 1.16.201, 1.16.210, 1.16.220, 1.17.0, 1.17.10, 1.17.30, 1.17.40, 1.18.0
  - Parse and serialize packets as JavaScript objects
  - Automatically respond to keep-alive packets
  - [Proxy and mitm connections](docs/API.md#proxy-docs)

--- a/src/options.js
+++ b/src/options.js
@@ -3,9 +3,9 @@ const mcData = require('minecraft-data')
 // Minimum supported version (< will be kicked)
 const MIN_VERSION = '1.16.201'
 // Currently supported verson. Note, clients with newer versions can still connect as long as data is in minecraft-data
-const CURRENT_VERSION = '1.17.40'
+const CURRENT_VERSION = '1.18.0'
 
-const Versions = Object.fromEntries(mcData.versions.bedrock.filter(e => e.releaseType === 'release').map(e => [e.minecraftVersion, e.version]))
+const Versions = Object.fromEntries(mcData.versions.bedrock.filter(e => e.releaseType === 'release').map(e => [e.minecraftVersion, e.version]).reverse())
 
 const defaultOptions = {
   // https://minecraft.gamepedia.com/Protocol_version#Bedrock_Edition_2

--- a/test/internal.js
+++ b/test/internal.js
@@ -206,5 +206,5 @@ async function timedTest (version, timeout = 1000 * 220) {
   console.info('✔ ok')
 }
 
-// if (!module.parent) timedTest()
+// if (!module.parent) timedTest('1.17.40')
 module.exports = { startTest, timedTest, requestChunks }

--- a/tools/startVanillaServer.js
+++ b/tools/startVanillaServer.js
@@ -12,7 +12,7 @@ const get = (url, out) => cp.execSync(`curl -o ${out} ${url}`)
 function fetchLatestStable () {
   get('https://raw.githubusercontent.com/minecraft-linux/mcpelauncher-versiondb/master/versions.json', 'versions.json')
   const versions = JSON.parse(fs.readFileSync('./versions.json'))
-  const latest = versions[versions.length - 1]
+  const latest = versions[0]
   return latest.version_name
 }
 


### PR DESCRIPTION
* reverse the version list to do the tests in descending order (1.18 -> 1.16)