### PR TITLE
Fix port collision caused by race condition in tests

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -24,6 +24,8 @@ declare module "bedrock-protocol" {
   }
 
   export interface ClientOptions extends Options {
+    // The username to connect to the server as
+    username: string,
     // The view distance in chunks
     viewDistance?: number,
     // Specifies which game edition to sign in as. Optional, but some servers verify this.

--- a/tools/genPacketDumps.js
+++ b/tools/genPacketDumps.js
@@ -18,11 +18,10 @@ function hasDumps (version) {
 let loop
 
 async function dump (version, force = true) {
-  const random = ((Math.random() * 100) | 0)
-  const port = 19130 + random
+  const [v4, v6] = [19132 + ((Math.random() * 1000) | 0), 19133 + ((Math.random() * 1000) | 0)]
 
   console.log('Starting dump server', version)
-  const handle = await vanillaServer.startServerAndWait(version || CURRENT_VERSION, 1000 * 120, { 'server-port': port })
+  const handle = await vanillaServer.startServerAndWait(version || CURRENT_VERSION, 1000 * 120, { 'server-port': v4, 'server-portv6': v6 })
 
   console.log('Started dump server', version)
   const client = new Client({

--- a/tools/genPacketDumps.js
+++ b/tools/genPacketDumps.js
@@ -19,10 +19,10 @@ let loop
 
 async function dump (version, force = true) {
   const random = (Math.random() * 1000) | 0
-  const [v4, v6] = [19132 + random, 19133 + random]
+  const [port, v6] = [19132 + random, 19133 + random]
 
   console.log('Starting dump server', version)
-  const handle = await vanillaServer.startServerAndWait(version || CURRENT_VERSION, 1000 * 120, { 'server-port': v4, 'server-portv6': v6 })
+  const handle = await vanillaServer.startServerAndWait(version || CURRENT_VERSION, 1000 * 120, { 'server-port': port, 'server-portv6': v6 })
 
   console.log('Started dump server', version)
   const client = new Client({

--- a/tools/genPacketDumps.js
+++ b/tools/genPacketDumps.js
@@ -18,7 +18,8 @@ function hasDumps (version) {
 let loop
 
 async function dump (version, force = true) {
-  const [v4, v6] = [19132 + ((Math.random() * 1000) | 0), 19133 + ((Math.random() * 1000) | 0)]
+  const random = (Math.random() * 1000) | 0
+  const [v4, v6] = [19132 + random, 19133 + random]
 
   console.log('Starting dump server', version)
   const handle = await vanillaServer.startServerAndWait(version || CURRENT_VERSION, 1000 * 120, { 'server-port': v4, 'server-portv6': v6 })


### PR DESCRIPTION
The ipv6 port is not randomized, if the previous ports for the last test didn't get freed in time, the server can crash on launch