### PR TITLE
Switch to sync zlib with 512k chunks, adjustable compression level

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -20,8 +20,8 @@ Returns a `Client` instance and connects to the server.
 | skipPing | *optional* | Whether pinging the server to check its version should be skipped. |
 | conLog | *optional* | Where to log connection information (server join, kick messages to). Defaults to console.log, set to `null` to not log anywhere. |
 | useNativeRaknet | *optional* | Whether to use the C++ version of RakNet. Set to false to use JS. |
-| authTitle | *optional* | The client ID to sign in as, defaults to Minecraft for Nintendo Switch. Set false to sign in through Azure. See prismarine-auth |
-| deviceType | *optional* | The device type to sign in as, defaults to "Nintendo". See prismarine-auth |
+| compressionLevel | *optional* | What zlib compression level to use, default to **7** |
+| batchingInterval | *optional* | How frequently, in milliseconds to flush and write the packet queue (default: 20ms) |
 
 The following events are emitted by the client:
 * 'status' - When the client's login sequence status has changed
@@ -30,6 +30,8 @@ The following events are emitted by the client:
 * 'kick' - The server has kicked the client
 * 'close' - The server has closed the connection
 * 'error' - An recoverable exception has happened. Not catching will throw an exception
+* 'connect_allowed' - Emitted after the client has pinged the server and gets version information.
+* 'heartbeat' - Emitted after two successful tick_sync (keepalive) packets have been sent bidirectionally
 
 ## be.createServer(options) : Server
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -21,6 +21,10 @@ declare module "bedrock-protocol" {
     useNativeRaknet?: boolean,
     // If using JS implementation of RakNet, should we use workers? (This only affects the client)
     useRaknetWorker?: boolean
+    // Compression level for zlib, default to 7
+    compressionLevel?: number
+    // How frequently the packet queue should be flushed in milliseconds, defaults to 20ms
+    batchingInterval?: number
   }
 
   export interface ClientOptions extends Options {

--- a/src/server.js
+++ b/src/server.js
@@ -33,6 +33,7 @@ class Server extends EventEmitter {
     if (this.options.protocolVersion < Options.MIN_VERSION) {
       throw new Error(`Protocol version < ${Options.MIN_VERSION} : ${this.options.protocolVersion}, too old`)
     }
+    this.compressionLevel = this.options.compressionLevel || 7
   }
 
   onOpenConnection = (conn) => {

--- a/src/serverPlayer.js
+++ b/src/serverPlayer.js
@@ -15,6 +15,7 @@ class Player extends Connection {
     this.deserializer = server.deserializer
     this.connection = connection
     this.options = server.options
+    this.compressionLevel = server.compressionLevel
 
     KeyExchange(this, server, server.options)
     Login(this, server, server.options)


### PR DESCRIPTION
* Switch to synchronous zlib with 512kb chunks, fixes an memory fragmentation related to async zlib in nodejs. Should also increase throughput by blocking event loop alot less. Related: https://github.com/websockets/ws/issues/1369 , https://github.com/nodejs/node/issues/8871 - not really a "memory leak" as GC does trigger, but memory starts to fragment and will crash the process if too many things in are in zlib queue 
* Customizable `compressionLevel` and `batchingInterval` in options
* Emit '`connect_allowed`' to match nmp, emitted after server ping
* Fix minor race condition in player spawning