### PR TITLE
Refactor client connection sequence

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -44,7 +44,7 @@ class Client extends Connection {
       const port = this.options.port
       this.connection = new RakClient({ useWorkers: this.options.useRaknetWorkers, host, port })
 
-      if (this.options.skipPing) {
+      if (!this.options.pingBeforeConnect) {
         this.emit('connect_allowed')
       } else { // Try to ping
         this.ping().then(data => {

--- a/src/client/auth.js
+++ b/src/client/auth.js
@@ -4,6 +4,30 @@ const minecraftFolderPath = require('minecraft-folder-path')
 const debug = require('debug')('minecraft-protocol')
 const { uuidFrom } = require('../datatypes/util')
 
+function validateOptions (options) {
+  if (!options.profilesFolder) {
+    options.profilesFolder = path.join(minecraftFolderPath, 'nmp-cache')
+  }
+  if (options.authTitle === undefined) {
+    options.authTitle = Titles.MinecraftNintendoSwitch
+    options.deviceType = 'Nintendo'
+  }
+}
+
+async function realmAuthenticate (options) {
+  validateOptions(options)
+  throw new Error('Not implemented')
+  // const authflow = new PrismarineAuth(options.username, options.profilesFolder, options, options.onMsaCode)
+  // const mcRealms = RealmAPI.from(authflow)
+  // // Set the options
+  // const realms = await mcRealms.getRealms()
+  // const realm = options.realms.pickRealm(realms)
+  // const [host, port] = await realm.getAddress()
+  // options.host = host
+  // options.port = port
+  // options.authflow = authflow
+}
+
 /**
  * Authenticates to Minecraft via device code based Microsoft auth,
  * then connects to the specified server in Client Options
@@ -13,16 +37,10 @@ const { uuidFrom } = require('../datatypes/util')
  * @param {object} options - Client Options
  */
 async function authenticate (client, options) {
-  if (!options.profilesFolder) {
-    options.profilesFolder = path.join(minecraftFolderPath, 'nmp-cache')
-  }
-  if (options.authTitle === undefined) {
-    options.authTitle = Titles.MinecraftNintendoSwitch
-    options.deviceType = 'Nintendo'
-  }
+  validateOptions(options)
   try {
-    const Authflow = new PrismarineAuth(options.username, options.profilesFolder, options, options.onMsaCode)
-    const chains = await Authflow.getMinecraftBedrockToken(client.clientX509).catch(e => {
+    const authflow = options.authflow || new PrismarineAuth(options.username, options.profilesFolder, options, options.onMsaCode)
+    const chains = await authflow.getMinecraftBedrockToken(client.clientX509).catch(e => {
       if (options.password) console.warn('Sign in failed, try removing the password field')
       throw e
     })
@@ -71,5 +89,6 @@ function postAuthenticate (client, profile, chains) {
 
 module.exports = {
   createOfflineSession,
-  authenticate
+  authenticate,
+  realmAuthenticate
 }

--- a/src/client/auth.js
+++ b/src/client/auth.js
@@ -17,15 +17,6 @@ function validateOptions (options) {
 async function realmAuthenticate (options) {
   validateOptions(options)
   throw new Error('Not implemented')
-  // const authflow = new PrismarineAuth(options.username, options.profilesFolder, options, options.onMsaCode)
-  // const mcRealms = RealmAPI.from(authflow)
-  // // Set the options
-  // const realms = await mcRealms.getRealms()
-  // const realm = options.realms.pickRealm(realms)
-  // const [host, port] = await realm.getAddress()
-  // options.host = host
-  // options.port = port
-  // options.authflow = authflow
 }
 
 /**

--- a/src/createClient.js
+++ b/src/createClient.js
@@ -9,7 +9,7 @@ function createClient (options) {
   assert(options)
   if (!options.skipPing) options.pingBeforeConnect = true
   const client = new Client({ port: 19132, ...options })
-  client.on('connect_allowed', connect)
+  client.on('connect_allowed', () => connect(client))
   return client
 }
 

--- a/src/createClient.js
+++ b/src/createClient.js
@@ -7,6 +7,7 @@ const advertisement = require('./server/advertisement')
 /** @param {{ version?: number, host: string, port?: number, connectTimeout?: number, skipPing?: boolean }} options */
 function createClient (options) {
   assert(options)
+  if (!options.skipPing) options.pingBeforeConnect = true
   const client = new Client({ port: 19132, ...options })
   client.on('connect_allowed', connect)
   return client

--- a/src/createClient.js
+++ b/src/createClient.js
@@ -15,10 +15,10 @@ function createClient (options) {
     if (options.skipPing) {
       client.init()
     } else {
-      ping({ host: options.host, port: options.port }).then(ad => {
+      ping(options).then(ad => {
         const adVersion = ad.version?.split('.').slice(0, 3).join('.') // Only 3 version units
         client.options.version = options.version ?? (Options.Versions[adVersion] ? adVersion : Options.CURRENT_VERSION)
-        this.conLog?.(`Connecting to server ${ad.motd} (${ad.name}), version ${ad.version}`, this.options.version !== ad.version ? ` (as ${this.options.version})` : '')
+        client.conLog?.(`Connecting to server ${ad.motd} (${ad.name}), version ${ad.version}`, client.options.version !== ad.version ? ` (as ${client.options.version})` : '')
         client.init()
       })
     }

--- a/src/createClient.js
+++ b/src/createClient.js
@@ -1,6 +1,5 @@
 const { Client } = require('./client')
 const { RakClient } = require('./rak')(true)
-const { Versions, CURRENT_VERSION } = require('./options')
 const { sleep } = require('./datatypes/util')
 const assert = require('assert')
 const advertisement = require('./server/advertisement')
@@ -9,19 +8,7 @@ const advertisement = require('./server/advertisement')
 function createClient (options) {
   assert(options)
   const client = new Client({ port: 19132, ...options })
-
-  if (options.skipPing) {
-    connect(client)
-  } else { // Try to ping
-    client.ping().then(data => {
-      const ad = advertisement.fromServerName(data)
-      client.options.version = options.version ?? (Versions[ad.version] ? ad.version : CURRENT_VERSION)
-      if (client.conLog) client.conLog(`Connecting to server ${ad.motd} (${ad.name}), version ${ad.version}`, client.options.version !== ad.version ? ` (as ${client.options.version})` : '')
-      client.emit('connect_allowed')
-      connect(client)
-    }, client)
-  }
-
+  client.on('connect_allowed', connect)
   return client
 }
 


### PR DESCRIPTION
* Allow connection information to come in after Client construction. Client emits "connect_allowed" similar to node-minecraft-protocol to signal when calling .connect is allowed
* Dummy implementation for realm handling