### PR TITLE
Implement Realm joining

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Example to connect to a Realm that the authenticating account is owner of or has
 const bedrock = require('bedrock-protocol')
 const client = bedrock.createClient({
   realms: {
-    pickRealm: (realms) => realms.find(realm => realm[0]) // Function which recieves an array of joined/owned Realms and must return a single Realm. Can be async
+    pickRealm: (realms) => realms[0] // Function which recieves an array of joined/owned Realms and must return a single Realm. Can be async
   }
 })
 ```

--- a/README.md
+++ b/README.md
@@ -59,6 +59,25 @@ client.on('text', (packet) => { // Listen for chat messages and echo them back.
 })
 ```
 
+### Client example joining a Realm
+
+Example to connect to a Realm that the authenticating account is owner of or has been invited to:
+
+```js
+const bedrock = require('bedrock-protocol')
+const client = bedrock.createClient({
+  realms: { // Only one option needs to be present
+    realmId: '1234567', // ID of the Realm to join
+    realmInvite: 'https://realms.gg/AB1CD2EFA3B' // Invite code or link for the Realm to join
+    pickRealm: (realms) => realms.find(realm => realm.name === 'Realm Name') // Function which recieves an array of joined/owned Realms and must return a single Realm. Can be async
+  }
+})
+
+client.on('text', (packet) => { // Listen for chat messages
+  console.log('Recieved Text:' packet)
+})
+```
+
 ### Server example
 
 *Can't connect locally on Windows? See the [faq](docs/FAQ.md)*

--- a/README.md
+++ b/README.md
@@ -66,15 +66,9 @@ Example to connect to a Realm that the authenticating account is owner of or has
 ```js
 const bedrock = require('bedrock-protocol')
 const client = bedrock.createClient({
-  realms: { // Only one option needs to be present
-    realmId: '1234567', // ID of the Realm to join
-    realmInvite: 'https://realms.gg/AB1CD2EFA3B' // Invite code or link for the Realm to join
-    pickRealm: (realms) => realms.find(realm => realm.name === 'Realm Name') // Function which recieves an array of joined/owned Realms and must return a single Realm. Can be async
+  realms: {
+    pickRealm: (realms) => realms.find(realm => realm[0]) // Function which recieves an array of joined/owned Realms and must return a single Realm. Can be async
   }
-})
-
-client.on('text', (packet) => { // Listen for chat messages
-  console.log('Recieved Text:' packet)
 })
 ```
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -8,7 +8,7 @@ Returns a `Client` instance and connects to the server.
 
 | Parameter   | Optionality | Description |
 | ----------- | ----------- |-|
-| host        | **Required** |  host to connect to, for example `127.0.0.1`. |
+| host        | Conditional | Not required if `realms` is set. host to connect to, for example `127.0.0.1`. |
 | port        | *optional* |  port to connect to, default to **19132**     |
 | version     | *optional* |  Version to connect as. If not specified, automatically match server version. |
 | offline     | *optional* |  default to **false**. Set this to true to disable Microsoft/Xbox auth.   |
@@ -22,6 +22,10 @@ Returns a `Client` instance and connects to the server.
 | useNativeRaknet | *optional* | Whether to use the C++ version of RakNet. Set to false to use JS. |
 | compressionLevel | *optional* | What zlib compression level to use, default to **7** |
 | batchingInterval | *optional* | How frequently, in milliseconds to flush and write the packet queue (default: 20ms) |
+| realms | *optional* | An object which should contain one of the following properties: `realmId`, `realmInvite`, `pickRealm`. When defined will attempt to join a Realm without needing to specify host/port. **The authenticated account must either own the Realm or have been invited to it** |
+| realms.realmId | *optional* | The id of the Realm to join. |
+| realms.realmInvite | *optional* | The invite link/code of the Realm to join. |
+| realms.pickRealm | *optional* | A function which will have an array of the user Realms (joined/owned) passed to it. The function should return a Realm. |
 
 The following events are emitted by the client:
 * 'status' - When the client's login sequence status has changed
@@ -133,6 +137,22 @@ Order of client event emissions:
 * 'login' - emitted after the client has been authenticated by the server
 * 'join' - the client is ready to recieve game packets after successful server-client handshake
 * 'spawn' - emitted after the client has permission from the server to spawn
+
+### Realm docs
+
+To make joining a Realm easier we've added an optional `realm` property to the client. It accepts the following options `realmId`, `realmInvite`, and `pickRealm`, supplying one of these will fetch host/port information for the specified Realm and then attempt to connect the bot.
+ - `realmId` - The id of the Realm to join.
+ - `realmInvite` - The invite code/link of the Realm to join.
+ - `pickRealm` - A function that will be called with a list of Realms to pick from. The function should return the Realm to join.
+
+```js
+const bedrock = require('bedrock-protocol')
+const client = bedrock.createClient({
+  realms: {
+    pickRealm: (realms) => realms[0] // Function which recieves an array of joined/owned Realms and must return a single Realm. Can be async
+  }
+})
+```
 
 ### Protocol docs
 

--- a/examples/client/realm.js
+++ b/examples/client/realm.js
@@ -1,0 +1,13 @@
+/* eslint-disable */
+const bedrock = require('bedrock-protocol')
+const client = bedrock.createClient({
+  realms: {
+    // realmId: '1234567',
+    // realmInvite: 'https://realms.gg/AB1CD2EFA3B',
+    pickRealm: (realms) => realms.find(e => e.name === 'Realm Name')
+  }
+})
+
+client.on('text', (packet) => { // Listen for chat messages
+    console.log('Received Text:', packet)
+})

--- a/examples/client/realm.js
+++ b/examples/client/realm.js
@@ -2,9 +2,9 @@
 const bedrock = require('bedrock-protocol')
 const client = bedrock.createClient({
   realms: {
-    // realmId: '1234567',
-    // realmInvite: 'https://realms.gg/AB1CD2EFA3B',
-    pickRealm: (realms) => realms.find(e => e.name === 'Realm Name')
+    // realmId: '1234567', // Connect the client to a Realm using the Realms ID
+    // realmInvite: 'https://realms.gg/AB1CD2EFA3B', // Connect the client to a Realm using the Realms invite URL or code
+    pickRealm: (realms) => realms.find(e => e.name === 'Realm Name') // Connect the client to a Realm using a function that returns a Realm
   }
 })
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,5 @@
 import EventEmitter from "events"
+import { Realm } from "prismarine-realms"
 
 declare module "bedrock-protocol" {
   type Version = '1.18.12' | '1.18.11' | '1.18.10' | '1.18.2' | '1.18.1' | '1.18.0' | '1.17.41' | '1.17.40' | '1.17.34' | '1.17.30' | '1.17.11' | '1.17.10' | '1.17.0' | '1.16.220' | '1.16.210' | '1.16.201'
@@ -40,6 +41,8 @@ declare module "bedrock-protocol" {
     skipPing?: boolean
     // where to log connection information to (default to console.log)
     conLog?
+    // used to join a Realm instead of supplying a host/port
+    realms?: RealmsOptions
   }
 
   export interface ServerOptions extends Options {
@@ -172,6 +175,12 @@ declare module "bedrock-protocol" {
     playersMax: number
     gamemode: string
     serverId: string
+  }
+
+  export interface RealmsOptions {
+    realmId: string
+    realmInvite: string 
+    pickRealm: (realms: Realm[]) => Realm
   }
 
   export function createClient(options: ClientOptions): Client

--- a/index.d.ts
+++ b/index.d.ts
@@ -178,9 +178,9 @@ declare module "bedrock-protocol" {
   }
 
   export interface RealmsOptions {
-    realmId: string
-    realmInvite: string 
-    pickRealm: (realms: Realm[]) => Realm
+    realmId?: string
+    realmInvite?: string 
+    pickRealm?: (realms: Realm[]) => Realm
   }
 
   export function createClient(options: ClientOptions): Client

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "minecraft-folder-path": "^1.2.0",
     "prismarine-auth": "^1.1.0",
     "prismarine-nbt": "^2.0.0",
-    "prismarine-realms": "github:PrismarineJS/prismarine-realms#pull/5",
+    "prismarine-realms": "^1.1.0",
     "protodef": "^1.14.0",
     "uuid-1345": "^1.0.2",
     "raknet-native": "^1.0.3"

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "minecraft-folder-path": "^1.2.0",
     "prismarine-auth": "^1.1.0",
     "prismarine-nbt": "^2.0.0",
+    "prismarine-realms": "github:PrismarineJS/prismarine-realms#pull/5",
     "protodef": "^1.14.0",
     "uuid-1345": "^1.0.2",
     "raknet-native": "^1.0.3"

--- a/src/client/auth.js
+++ b/src/client/auth.js
@@ -43,7 +43,7 @@ async function realmAuthenticate (options) {
 
   debug('realms', realms)
 
-  if (!realms || !realms.length) throw Error('Couldn\'t find any Realms for the authenticating account')
+  if (!realms || !realms.length) throw Error('Couldn\'t find any Realms for the authenticated account')
 
   let realm
 
@@ -56,7 +56,7 @@ async function realmAuthenticate (options) {
     realm = await options.realms.pickRealm(realms)
   }
 
-  if (!realm) throw Error('Couldn\'t find a Realm to connect to. Authenticating account must be owner or have joined the Realm.')
+  if (!realm) throw Error('Couldn\'t find a Realm to connect to. Authenticated account must be the owner or has been invited to the Realm.')
 
   const { address } = await retry(async () => realm.getAddress(), 5)
   const [host, port] = address.split(':')

--- a/src/client/auth.js
+++ b/src/client/auth.js
@@ -42,7 +42,7 @@ async function realmAuthenticate (options) {
 
   const { host, port } = await realm.getAddress()
 
-  debug('realms connection', address)
+  debug('realms connection', { host, port })
 
   options.host = host
   options.port = port

--- a/src/client/auth.js
+++ b/src/client/auth.js
@@ -15,24 +15,6 @@ function validateOptions (options) {
   }
 }
 
-function retry (fn, maxRetries, interval = 1000) {
-  return new Promise((resolve, reject) => {
-    let retries = 0
-    const retryFn = () => {
-      retries++
-      fn().then(resolve).catch(err => {
-        debug('retry', retries, err)
-        if (retries >= maxRetries) {
-          reject(err)
-        } else {
-          setTimeout(retryFn, interval)
-        }
-      })
-    }
-    retryFn()
-  })
-}
-
 async function realmAuthenticate (options) {
   validateOptions(options)
 
@@ -58,13 +40,12 @@ async function realmAuthenticate (options) {
 
   if (!realm) throw Error('Couldn\'t find a Realm to connect to. Authenticated account must be the owner or has been invited to the Realm.')
 
-  const { address } = await retry(async () => realm.getAddress(), 5)
-  const [host, port] = address.split(':')
+  const { host, port } = await realm.getAddress()
 
   debug('realms connection', address)
 
   options.host = host
-  options.port = parseInt(port)
+  options.port = port
 }
 
 /**

--- a/src/createClient.js
+++ b/src/createClient.js
@@ -15,7 +15,7 @@ function createClient (options) {
     if (options.skipPing) {
       client.init()
     } else {
-      ping(options).then(ad => {
+      ping(client.options).then(ad => {
         const adVersion = ad.version?.split('.').slice(0, 3).join('.') // Only 3 version units
         client.options.version = options.version ?? (Options.Versions[adVersion] ? adVersion : Options.CURRENT_VERSION)
         client.conLog?.(`Connecting to server ${ad.motd} (${ad.name}), version ${ad.version}`, client.options.version !== ad.version ? ` (as ${client.options.version})` : '')


### PR DESCRIPTION
Will allow connecting to Bedrock Realms without needing to manually fetch host/port information. Currently depends on https://github.com/PrismarineJS/prismarine-realms/pull/5. 