### PR TITLE
Make CI more reliable

### DIFF
--- a/tools/genPacketDumps.js
+++ b/tools/genPacketDumps.js
@@ -22,7 +22,7 @@ async function dump (version, force = true) {
   const [port, v6] = [19132 + random, 19133 + random]
 
   console.log('Starting dump server', version)
-  const handle = await vanillaServer.startServerAndWait(version || CURRENT_VERSION, 1000 * 120, { 'server-port': port, 'server-portv6': v6 })
+  const handle = await vanillaServer.startServerAndWait2(version || CURRENT_VERSION, 1000 * 120, { 'server-port': port, 'server-portv6': v6 })
 
   console.log('Started dump server', version)
   const client = new Client({

--- a/tools/startVanillaServer.js
+++ b/tools/startVanillaServer.js
@@ -15,7 +15,7 @@ function get (url, outPath) {
       response.on('finish', () => {
         file.close()
         resolve()
-      }
+      })
     })
   })
 }

--- a/tools/startVanillaServer.js
+++ b/tools/startVanillaServer.js
@@ -128,6 +128,8 @@ async function startServerAndWait2 (version, withTimeout, options) {
     return await startServerAndWait(version, withTimeout, options)
   } catch (e) {
     console.log(e, 'tring once more to start server...')
+    process.chdir(__dirname)
+    fs.rmSync('bds-' + version, { recursive: true })
     return await startServerAndWait(version, withTimeout, options)
   }
 }

--- a/tools/startVanillaServer.js
+++ b/tools/startVanillaServer.js
@@ -2,10 +2,23 @@ const http = require('https')
 const fs = require('fs')
 const cp = require('child_process')
 const debug = require('debug')('minecraft-protocol')
+const htps = require('https')
 const { getFiles, waitFor } = require('../src/datatypes/util')
 
 const head = (url) => new Promise((resolve, reject) => http.request(url, { method: 'HEAD' }, resolve).on('error', reject).end())
-const get = (url, out) => cp.execSync(`curl -o ${out} ${url}`)
+function get (url, outPath) {
+  const file = fs.createWriteStream(outPath)
+  return new Promise((resolve, reject) => {
+    https.get(url, { timeout: 1000 * 20 }, response => {
+      if (response.statusCode !== 200) return reject()
+      response.pipe(file)
+      response.on('finish', () => {
+        file.close()
+        resolve()
+      }
+    })
+  })
+}
 
 // Get the latest versions
 // TODO: once we support multi-versions

--- a/tools/startVanillaServer.js
+++ b/tools/startVanillaServer.js
@@ -36,13 +36,11 @@ async function download (os, version, path = 'bds-') {
   const dir = path + version
 
   if (fs.existsSync(dir) && getFiles(dir).length) {
-    console.log('Entering', path + version)
     process.chdir(path + version) // Enter server folder
     return verStr
   }
   try { fs.mkdirSync(dir) } catch { }
 
-  console.log('entering', path + version)
   process.chdir(path + version) // Enter server folder
   const url = (os, version) => `https://minecraft.azureedge.net/bin-${os}/bedrock-server-${version}.zip`
 


### PR DESCRIPTION
[Use 2-attempt server start method in dump test](https://github.com/PrismarineJS/bedrock-protocol/commit/e4a932118d3a42120f5dd79f7178ab69c347aafc) to make tests a bit more reliable (seems to occasionally timeout here on server start)

Fix #216 