### PR TITLE
Better handle ping_timeout, update documentation

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -38,7 +38,6 @@ The following special events are emitted by the client on top of protocol packet
 * 'heartbeat' - Emitted after two successful tick_sync (keepalive) packets have been sent bidirectionally
 * 'packet' - Emitted for all packets received by client
 * 'session' - When the client has finished authenticating and connecting
-* 'ping_timeout' - When the underlying network protocol is unable to connect to the server
 
 ## be.createServer(options) : Server
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -37,6 +37,8 @@ The following special events are emitted by the client on top of protocol packet
 * 'connect_allowed' - Emitted after the client has pinged the server and gets version information.
 * 'heartbeat' - Emitted after two successful tick_sync (keepalive) packets have been sent bidirectionally
 * 'packet' - Emitted for all packets received by client
+* 'session' - When the client has finished authenticating and connecting
+* 'ping_timeout' - When the underlying network protocol is unable to connect to the server
 
 ## be.createServer(options) : Server
 

--- a/src/createClient.js
+++ b/src/createClient.js
@@ -21,13 +21,7 @@ function createClient (options) {
         client.options.version = options.version ?? (Options.Versions[adVersion] ? adVersion : Options.CURRENT_VERSION)
         client.conLog?.(`Connecting to server ${ad.motd} (${ad.name}), version ${ad.version}`, client.options.version !== ad.version ? ` (as ${client.options.version})` : '')
         client.init()
-      }).catch(e => {
-        if (e instanceof RakTimeout) {
-          client.emit('ping_timeout')
-        } else {
-          throw e
-        }
-      })
+      }).catch(e => client.emit('error', e))
     }
   }
 

--- a/src/createClient.js
+++ b/src/createClient.js
@@ -27,7 +27,7 @@ function createClient (options) {
         } else {
           throw e
         }
-      });
+      })
     }
   }
 

--- a/src/createClient.js
+++ b/src/createClient.js
@@ -1,5 +1,5 @@
 const { Client } = require('./client')
-const { RakClient, RakTimeout } = require('./rak')(true)
+const { RakClient } = require('./rak')(true)
 const { sleep } = require('./datatypes/util')
 const assert = require('assert')
 const Options = require('./options')


### PR DESCRIPTION
This is to fix a few things I've come across in my development:

- Better handle the ping_timeout issue. Currently this causes a non-catchable error (as its thrown from a promise). This allows clients to monitor for the `client.on('ping_timeout')` emission and handle it accordingly. A workaround for this is to skip the ping step, however that leads to a second issue.
- When ping is skipped, `createClient` never actually connects. This is because `client.init` emits `connect_allowed`, but the listener is not set up until the end of `onServerInfo`. This is not an issue under normal conditions as `ping(...)` results in an async network call prior to calling `client.init`.

I was going to add an event for "client authenticated" but reviewing the code it looks like `session` already does that and had just needed to be added to the documentation. 