### PR TITLE
Add Port Redirect Functionality

### DIFF
--- a/src/createClient.js
+++ b/src/createClient.js
@@ -19,7 +19,12 @@ function createClient (options) {
       ping(client.options).then(ad => {
         const adVersion = ad.version?.split('.').slice(0, 3).join('.') // Only 3 version units
         client.options.version = options.version ?? (Options.Versions[adVersion] ? adVersion : Options.CURRENT_VERSION)
-        client.conLog?.(`Connecting to server ${ad.motd} (${ad.name}), version ${ad.version}`, client.options.version !== ad.version ? ` (as ${client.options.version})` : '')
+
+        if (ad.port) {
+          client.options.port = ad.port
+        }
+
+        client.conLog?.(`Connecting to ${client.options.host}:${client.options.port} ${ad.motd} (${ad.levelName}), version ${ad.version}`, client.options.version !== ad.version ? ` (as ${client.options.version})` : '')
         client.init()
       }).catch(e => client.emit('error', e))
     }

--- a/src/server/advertisement.js
+++ b/src/server/advertisement.js
@@ -7,6 +7,9 @@ class ServerAdvertisement {
   playersMax = 5
   gamemode = 'Creative'
   serverId = '0'
+  gamemodeId = 1
+  port = undefined
+  portV6 = undefined
 
   constructor (obj, version = CURRENT_VERSION) {
     if (obj?.name) obj.motd = obj.name
@@ -16,8 +19,13 @@ class ServerAdvertisement {
   }
 
   fromString (str) {
-    const [header, motd, protocol, version, playersOnline, playersMax, serverId, levelName, gamemode] = str.split(';')
-    Object.assign(this, { header, motd, protocol, version, playersOnline, playersMax, serverId, levelName, gamemode })
+    const [header, motd, protocol, version, playersOnline, playersMax, serverId, levelName, gamemode, gamemodeId, port, portV6] = str.split(';')
+    Object.assign(this, { header, motd, protocol, version, playersOnline, playersMax, serverId, levelName, gamemode, gamemodeId, port, portV6 })
+    for (const numeric of ['playersOnline', 'playersMax', 'gamemodeId', 'port', 'portV6']) {
+      if (this[numeric] !== undefined) {
+        this[numeric] = parseInt(this[numeric])
+      }
+    }
     return this
   }
 


### PR DESCRIPTION
This takes the guesswork out of finding ports, particularly important for users trying to connect to client-based servers.

The server will only advertise over 19132 but will not accept game connections to it (rather reporting that the server is full).

This will rewrite the port in the options, allowing the user to easily connect to the server. This also allows the safe assumption of port 19132 always being the default, as using that we can then find the correct port, simplifying end-user configuration.

Reference: https://wiki.vg/Raknet_Protocol#Unconnected_Pong

Output: `Connecting to 192.168.0.191:45388 BlahBlah (My World), version 1.19.40.20  (as 1.19.30)`