### PR TITLE
Port Redirect Fix - Only Redirect on Unspecified Port

### DIFF
--- a/src/createClient.js
+++ b/src/createClient.js
@@ -9,7 +9,7 @@ const auth = require('./client/auth')
 /** @param {{ version?: number, host: string, port?: number, connectTimeout?: number, skipPing?: boolean }} options */
 function createClient (options) {
   assert(options)
-  const client = new Client({ port: 19132, ...options, delayedInit: true })
+  const client = new Client({ ...options, delayedInit: true })
 
   function onServerInfo () {
     client.on('connect_allowed', () => connect(client))
@@ -20,11 +20,11 @@ function createClient (options) {
         const adVersion = ad.version?.split('.').slice(0, 3).join('.') // Only 3 version units
         client.options.version = options.version ?? (Options.Versions[adVersion] ? adVersion : Options.CURRENT_VERSION)
 
-        if (ad.port) {
-          client.options.port = ad.port
+        if (client.options.port === undefined) {
+          client.options.port = ad.port || Options.DEFAULT_PORT
         }
 
-        client.conLog?.(`Connecting to ${client.options.host}:${client.options.port} ${ad.motd} (${ad.levelName}), version ${ad.version}`, client.options.version !== ad.version ? ` (as ${client.options.version})` : '')
+        client.conLog?.(`Connecting to ${client.options.host}:${client.options.port} ${ad.motd} (${ad.levelName}), version ${ad.version} ${client.options.version !== ad.version ? ` (as ${client.options.version})` : ''}`)
         client.init()
       }).catch(e => client.emit('error', e))
     }
@@ -84,6 +84,7 @@ function connect (client) {
 }
 
 async function ping ({ host, port }) {
+  port = port || Options.DEFAULT_PORT
   const con = new RakClient({ host, port })
   try {
     return advertisement.fromServerName(await con.ping())

--- a/src/options.js
+++ b/src/options.js
@@ -4,6 +4,8 @@ const mcData = require('minecraft-data')
 const MIN_VERSION = '1.16.201'
 // Currently supported verson. Note, clients with newer versions can still connect as long as data is in minecraft-data
 const CURRENT_VERSION = '1.19.21'
+// The default port to be used
+const DEFAULT_PORT = 19132
 
 const Versions = Object.fromEntries(mcData.versions.bedrock.filter(e => e.releaseType === 'release').map(e => [e.minecraftVersion, e.version]))
 
@@ -39,4 +41,4 @@ function validateOptions (options) {
   if (options.useNativeRaknet === false) options.raknetBackend = 'jsp-raknet'
 }
 
-module.exports = { defaultOptions, MIN_VERSION, CURRENT_VERSION, Versions, validateOptions }
+module.exports = { defaultOptions, MIN_VERSION, CURRENT_VERSION, DEFAULT_PORT, Versions, validateOptions }


### PR DESCRIPTION
This will only overwrite the port with the advertised port when otherwise unspecified, changing the default behavior a bit.