### PR TITLE
Allow CLI Options for Examples

### DIFF
--- a/examples/client/client.js
+++ b/examples/client/client.js
@@ -22,6 +22,7 @@ const options = {
 
 // if an address is specified from the command line, use that.
 if (process.argv[2]) {
+  ['host', 'port'].forEach(k => delete options[k])
   Object.assign(options, bedrock.parseAddress(...process.argv.slice(2)))
 }
 

--- a/examples/client/client.js
+++ b/examples/client/client.js
@@ -1,13 +1,34 @@
 /* eslint-disable */
+/**
+ * Creates a client and echos the in-game chat
+ * 
+ * 
+ * Examples:
+ *   node examples/client.js
+ *   node examples/client.js 127.0.0.1:19132
+ *   node examples/client.js --realm_id 1234
+ *   node examples/client.js --realm_invite "https://realms.gg/AB1CD2EFA3B"
+ *   node examples/client.js --realm_name "My World"
+ */
+
 const bedrock = require('bedrock-protocol')
-const client = bedrock.createClient({
+
+const options = {
   host: 'localhost',   // optional
   port: 19132,         // optional, default 19132
   username: 'Notch',   // the username you want to join as, optional if online mode
   offline: false      // optional, default false. if true, do not login with Xbox Live. You will not be asked to sign-in if set to true.
-})
+}
+
+// if an address is specified from the command line, use that.
+if (process.argv[2]) {
+  Object.assign(options, bedrock.parseAddress(...process.argv.slice(2)))
+}
+
+const client = bedrock.createClient(options)
 
 client.on('text', (packet) => { // Listen for chat messages and echo them back.
+  console.log('Received Text:', packet)
   if (packet.source_name != client.username) {
     client.queue('text', {
       type: 'chat', needs_translation: false, source_name: client.username, xuid: '', platform_chat_id: '',

--- a/examples/client/realm.js
+++ b/examples/client/realm.js
@@ -1,12 +1,19 @@
 /* eslint-disable */
 const bedrock = require('bedrock-protocol')
-const client = bedrock.createClient({
+
+const options = {
   realms: {
     // realmId: '1234567', // Connect the client to a Realm using the Realms ID
     // realmInvite: 'https://realms.gg/AB1CD2EFA3B', // Connect the client to a Realm using the Realms invite URL or code
     pickRealm: (realms) => realms.find(e => e.name === 'Realm Name') // Connect the client to a Realm using a function that returns a Realm
   }
-})
+}
+
+if (process.argv[3]) {
+  Object.apply(options, bedrock.parseAddress(...process.argv.slice(2, 4)))
+}
+
+const client = bedrock.createClient(options)
 
 client.on('text', (packet) => { // Listen for chat messages
     console.log('Received Text:', packet)

--- a/examples/createRelay.js
+++ b/examples/createRelay.js
@@ -1,20 +1,60 @@
+/**
+ * A simple relay to demonstrate connectivity.
+ * 
+ * Command line options accepted are:
+ *  - serverAddress (optional, required if destinationAddress used):
+ *      - default: "0.0.0.0:19130"
+ *      - "{host}"
+ *      - "{host:port}"
+ *  - destinationAddress (optional):
+ *      - default: "127.0.0.1:19132"
+ *      - "{host}"
+ *      - "{host:port}"
+ *      - "--realm_id" "{id}"
+ *      - "--realm_invite" "{invite_link}"
+ *      - "--realm_name" "{name}"
+ * 
+ * Examples:
+ *   node examples/createRelay.js
+ *   node examples/createRelay.js 127.0.0.1:19132
+ *   node examples/createRelay.js 127.0.0.1:19132 127.0.0.1:19134
+ *   node examples/createRelay.js 127.0.0.1:19132 --realm_id 1234
+ *   node examples/createRelay.js 127.0.0.1:19132 --realm_invite "https://realms.gg/AB1CD2EFA3B"
+ *   node examples/createRelay.js 127.0.0.1:19132 --realm_name "My World"
+ */
+
 const { Relay } = require('bedrock-protocol')
+
+const options = {
+  /* host and port for clients to listen to */
+  host: '0.0.0.0',
+  port: 19130,
+  offline: false,
+  /* Where to send upstream packets to */
+  destination: {
+    host: '127.0.0.1',
+    port: 19132,
+    offline: false
+  }
+}
+
+if (process.argv[2]) {
+  Object.apply(options, bedrock.parseAddress(process.argv[2]))
+  if (options.port === undefined) {
+    options.port = 19132
+  }
+}
+if (process.argv[3]) {
+  options.destination = bedrock.parseAddress(...process.argv.slice(3))
+  if (options.destination.host && options.destination.port === undefined) {
+    options.destination.port = 19132
+  }
+}
 
 function createRelay () {
   console.log('Creating relay')
   /* Example to create a non-transparent proxy (or 'Relay') connection to destination server */
-  const relay = new Relay({
-    /* host and port for clients to listen to */
-    host: '0.0.0.0',
-    port: 19130,
-    offline: false,
-    /* Where to send upstream packets to */
-    destination: {
-      host: '127.0.0.1',
-      port: 19132,
-      offline: false
-    }
-  })
+  const relay = new Relay(options)
   relay.conLog = console.debug
   relay.listen()
 }

--- a/examples/createRelay.js
+++ b/examples/createRelay.js
@@ -1,6 +1,6 @@
 /**
  * A simple relay to demonstrate connectivity.
- * 
+ *
  * Command line options accepted are:
  *  - serverAddress (optional, required if destinationAddress used):
  *      - default: "0.0.0.0:19130"
@@ -13,7 +13,7 @@
  *      - "--realm_id" "{id}"
  *      - "--realm_invite" "{invite_link}"
  *      - "--realm_name" "{name}"
- * 
+ *
  * Examples:
  *   node examples/createRelay.js
  *   node examples/createRelay.js 127.0.0.1:19132
@@ -23,7 +23,7 @@
  *   node examples/createRelay.js 127.0.0.1:19132 --realm_name "My World"
  */
 
-const { Relay } = require('bedrock-protocol')
+const bedrock = require('bedrock-protocol')
 
 const options = {
   /* host and port for clients to listen to */
@@ -54,7 +54,7 @@ if (process.argv[3]) {
 function createRelay () {
   console.log('Creating relay')
   /* Example to create a non-transparent proxy (or 'Relay') connection to destination server */
-  const relay = new Relay(options)
+  const relay = new bedrock.Relay(options)
   relay.conLog = console.debug
   relay.listen()
 }

--- a/examples/ping.js
+++ b/examples/ping.js
@@ -15,6 +15,7 @@ const options = { host: 'play.cubecraft.net', port: 19132 }
 
 // if an address is specified from the command line, use that.
 if (process.argv[2]) {
+  ['host', 'port'].forEach(k => delete options[k])
   Object.assign(options, bedrock.parseAddress(...process.argv.slice(2)))
   if (options.port === undefined) {
     options.port = 19132

--- a/examples/ping.js
+++ b/examples/ping.js
@@ -1,5 +1,26 @@
-const { ping } = require('bedrock-protocol')
+/**
+ * Ping a server to retrieve metadata
+ * 
+ * Examples:
+ *   node examples/ping.js
+ *   node examples/ping.js 127.0.0.1:19132
+ *   node examples/ping.js --realm_id 1234
+ *   node examples/ping.js --realm_invite "https://realms.gg/AB1CD2EFA3B"
+ *   node examples/ping.js --realm_name "My World"
+ */
 
-ping({ host: 'play.cubecraft.net', port: 19132 }).then(res => {
+const bedrock = require('bedrock-protocol')
+
+const options = { host: 'play.cubecraft.net', port: 19132 }
+
+// if an address is specified from the command line, use that.
+if (process.argv[2]) {
+  Object.assign(options, bedrock.parseAddress(...process.argv.slice(2)))
+  if (options.port === undefined) {
+    options.port = 19132
+  }
+}
+
+bedrock.ping(options).then(res => {
   console.log(res)
 })

--- a/examples/ping.js
+++ b/examples/ping.js
@@ -1,6 +1,6 @@
 /**
  * Ping a server to retrieve metadata
- * 
+ *
  * Examples:
  *   node examples/ping.js
  *   node examples/ping.js 127.0.0.1:19132

--- a/examples/relay.js
+++ b/examples/relay.js
@@ -1,6 +1,6 @@
 /**
  * A simple relay to demonstrate connectivity.
- * 
+ *
  * Command line options accepted are:
  *  - serverAddress (optional, required if destinationAddress used):
  *      - default: "0.0.0.0:19130"
@@ -13,7 +13,7 @@
  *      - "--realm_id" "{id}"
  *      - "--realm_invite" "{invite_link}"
  *      - "--realm_name" "{name}"
- * 
+ *
  * Examples:
  *   node examples/relay.js
  *   node examples/relay.js 127.0.0.1:19132
@@ -27,7 +27,7 @@ const bedrock = require('bedrock-protocol')
 
 // Start your server first on port 19132.
 
-options = {
+const options = {
   version: '1.16.220', // The version
   /* host and port to listen for clients on */
   host: '0.0.0.0',

--- a/examples/relay.js
+++ b/examples/relay.js
@@ -1,19 +1,59 @@
-const { Relay } = require('bedrock-protocol')
+/**
+ * A simple relay to demonstrate connectivity.
+ * 
+ * Command line options accepted are:
+ *  - serverAddress (optional, required if destinationAddress used):
+ *      - default: "0.0.0.0:19130"
+ *      - "{host}"
+ *      - "{host:port}"
+ *  - destinationAddress (optional):
+ *      - default: "127.0.0.1:19132"
+ *      - "{host}"
+ *      - "{host:port}"
+ *      - "--realm_id" "{id}"
+ *      - "--realm_invite" "{invite_link}"
+ *      - "--realm_name" "{name}"
+ * 
+ * Examples:
+ *   node examples/relay.js
+ *   node examples/relay.js 127.0.0.1:19132
+ *   node examples/relay.js 127.0.0.1:19132 127.0.0.1:19134
+ *   node examples/relay.js 127.0.0.1:19132 --realm_id 1234
+ *   node examples/relay.js 127.0.0.1:19132 --realm_invite "https://realms.gg/AB1CD2EFA3B"
+ *   node examples/relay.js 127.0.0.1:19132 --realm_name "My World"
+ */
 
-// Start your server first on port 19131.
+const bedrock = require('bedrock-protocol')
 
-// Start the proxy server
-const relay = new Relay({
+// Start your server first on port 19132.
+
+options = {
   version: '1.16.220', // The version
   /* host and port to listen for clients on */
   host: '0.0.0.0',
-  port: 19132,
+  port: 19130,
   /* Where to send upstream packets to */
   destination: {
     host: '127.0.0.1',
-    port: 19131
+    port: 19132
   }
-})
+}
+
+if (process.argv[2]) {
+  Object.apply(options, bedrock.parseAddress(process.argv[2]))
+  if (options.port === undefined) {
+    options.port = 19132
+  }
+}
+if (process.argv[3]) {
+  options.destination = bedrock.parseAddress(...process.argv.slice(3))
+  if (options.destination.host && options.destination.port === undefined) {
+    options.destination.port = 19132
+  }
+}
+
+// Start the proxy server
+const relay = new bedrock.Relay(options)
 relay.conLog = console.debug
 relay.listen() // Tell the server to start listening.
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -11,7 +11,7 @@ declare module "bedrock-protocol" {
     version?: string
     // For the client, the host of the server to connect to (default: 127.0.0.1)
     // For the server, the host to bind to (default: 0.0.0.0)
-    host: string
+    host?: string
     // The port to connect or bind to, default: 19132
     port?: number
     // For the client, if we should login with Microsoft/Xbox Live.
@@ -198,6 +198,8 @@ declare module "bedrock-protocol" {
 
   export function createClient(options: ClientOptions): Client
   export function createServer(options: ServerOptions): Server
+
+  export function parseAddress(address: string): Options
 
   export function ping({ host, port }: { host: string, port: number }): Promise<ServerAdvertisement>
 }

--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ if (typeof process !== 'undefined' && parseInt(process.versions.node.split('.')[
 const { Client } = require('./src/client')
 const { Server } = require('./src/server')
 const { Relay } = require('./src/relay')
-const { createClient, ping } = require('./src/createClient')
+const { createClient, ping, parseAddress } = require('./src/createClient')
 const { createServer } = require('./src/createServer')
 const { Titles } = require('prismarine-auth')
 
@@ -17,6 +17,7 @@ module.exports = {
   Relay,
   createClient,
   ping,
+  parseAddress,
   createServer,
   title: Titles
 }

--- a/src/createClient.js
+++ b/src/createClient.js
@@ -92,4 +92,30 @@ async function ping ({ host, port }) {
   }
 }
 
-module.exports = { createClient, ping }
+// Parse an address given a variable number of cli arguments
+function parseAddress (...args) {
+  console.log(args)
+  if (args.length == 0) return {}
+  // 1 argument: host with optional port
+  if (args.length == 1) {
+    const parts = args[0].split(':')
+    if (parts[1]) {
+      parts[1] = parseInt(parts[1])
+    }
+    return { host: parts[0], port: parts[1] }
+  }
+  // 2 (or more) arguments
+  switch (args[0]) {
+    case '--realm_id':
+      return { realms: { realmId: args[1] } }
+    case '--realm_invite':
+      return { realms: { realmInvite: args[1] } }
+    case '--realm_name':
+      return { realms: { pickRealm: (realms) => {
+        realms.find(e => e.name === args[1])
+      }} }
+    default: throw new Error(`Unrecognized Argument: ${args[0]}`)
+  }
+}
+
+module.exports = { createClient, ping, parseAddress }

--- a/src/createClient.js
+++ b/src/createClient.js
@@ -94,7 +94,6 @@ async function ping ({ host, port }) {
 
 // Parse an address given a variable number of cli arguments
 function parseAddress (...args) {
-  console.log(args)
   if (args.length == 0) return {}
   // 1 argument: host with optional port
   if (args.length == 1) {

--- a/src/createClient.js
+++ b/src/createClient.js
@@ -94,9 +94,9 @@ async function ping ({ host, port }) {
 
 // Parse an address given a variable number of cli arguments
 function parseAddress (...args) {
-  if (args.length == 0) return {}
+  if (args.length === 0) return {}
   // 1 argument: host with optional port
-  if (args.length == 1) {
+  if (args.length === 1) {
     const parts = args[0].split(':')
     if (parts[1]) {
       parts[1] = parseInt(parts[1])
@@ -110,9 +110,13 @@ function parseAddress (...args) {
     case '--realm_invite':
       return { realms: { realmInvite: args[1] } }
     case '--realm_name':
-      return { realms: { pickRealm: (realms) => {
-        realms.find(e => e.name === args[1])
-      }} }
+      return {
+        realms: {
+          pickRealm: (realms) => {
+            realms.find(e => e.name === args[1])
+          }
+        }
+      }
     default: throw new Error(`Unrecognized Argument: ${args[0]}`)
   }
 }


### PR DESCRIPTION
A really basic CLI parsing setup that allows for out-of-the-box running of these examples. 

Motiivation: I use these to test changes on bedrock-server and I've actually keep some secondary scripts with my own server details around to run these. With these flags though, no code changes are needed for simple demos.

Also this will reduce/eliminate the chance of personal info accidentally being entered into bedrock-protocol code.

Three concerns I see with this:

 - A lot of the logic that separated these files is now gone. For instance, createRelay and realmRelay can do the same thing. I kept realmRelay for its demonstrative value though.
 - Not crazy about the parse function living in createClient...
 - The argument parsing is very limited as I didn't want to add a new dependency for such a minor feature. I would love to expand this further for some other examples I have (I have a pretty good relay that allows packet inspection that I would like to include), but that would likely stretch the arg-parsing logic to the point where it should have a dedicated JS file in `examples/` (say `examples/lib/args.js`). This would also solve the above createClient concern.