### PR TITLE
1.19.30 support, improve error handling and server pong data

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -103,7 +103,10 @@ class Client extends Connection {
         this.sendLogin()
       }
     }
-    this.connection.onCloseConnection = (reason) => this.close()
+    this.connection.onCloseConnection = (reason) => {
+      if (this.status === ClientStatus.Disconnected) this.conLog?.(`Server closed connection: ${reason}`)
+      this.close()
+    }
     this.connection.onEncapsulated = this.onEncapsulated
     this.connection.connect()
 

--- a/src/client.js
+++ b/src/client.js
@@ -23,8 +23,10 @@ class Client extends Connection {
 
     this.startGameData = {}
     this.clientRuntimeId = null
-    // Start off without compression
-    this.compressionAlgorithm = 'none'
+    // Start off without compression on 1.19.30, zlib on below
+    this.compressionAlgorithm = this.versionGreaterThanOrEqualTo('1.19.30') ? 'none' : 'deflate'
+    this.compressionThreshold = 512
+    this.compressionLevel = this.options.compressionLevel
 
     if (isDebug) {
       this.inLog = (...args) => debug('C ->', ...args)
@@ -114,7 +116,7 @@ class Client extends Connection {
   }
 
   updateCompressorSettings (packet) {
-    this.compressionAlgorithm = packet.compression_algorithm
+    this.compressionAlgorithm = packet.compression_algorithm || 'deflate'
     this.compressionThreshold = packet.compression_threshold
   }
 

--- a/src/client.js
+++ b/src/client.js
@@ -1,7 +1,6 @@
 const { ClientStatus, Connection } = require('./connection')
 const { createDeserializer, createSerializer } = require('./transforms/serializer')
 const { serialize, isDebug } = require('./datatypes/util')
-const { Framer, DeflateFramer, SnappyFramer } = require('./transforms/framer')
 const debug = require('debug')('minecraft-protocol')
 const Options = require('./options')
 const auth = require('./client/auth')
@@ -25,7 +24,7 @@ class Client extends Connection {
     this.startGameData = {}
     this.clientRuntimeId = null
     // Start off without compression
-    this.Framer = Framer
+    this.compressionAlgorithm = 'none'
 
     if (isDebug) {
       this.inLog = (...args) => debug('C ->', ...args)
@@ -115,14 +114,7 @@ class Client extends Connection {
   }
 
   updateCompressorSettings (packet) {
-    switch (packet.compression_algorithm) {
-      case 'deflate':
-        this.Framer = DeflateFramer
-        break
-      case 'snappy':
-        this.Framer = SnappyFramer
-        break
-    }
+    this.compressionAlgorithm = packet.compression_algorithm
     this.compressionThreshold = packet.compression_threshold
   }
 

--- a/src/datatypes/util.js
+++ b/src/datatypes/util.js
@@ -23,11 +23,11 @@ function sleep (ms) {
 async function waitFor (cb, withTimeout, onTimeout) {
   let t
   const ret = await Promise.race([
-    new Promise(resolve => cb(resolve)),
+    new Promise((resolve, reject) => cb(resolve, reject)),
     new Promise(resolve => { t = setTimeout(() => resolve('timeout'), withTimeout) })
   ])
   clearTimeout(t)
-  if (ret === 'timeout') onTimeout()
+  if (ret === 'timeout') await onTimeout()
   return ret
 }
 

--- a/src/options.js
+++ b/src/options.js
@@ -21,7 +21,14 @@ const defaultOptions = {
   // Specifies the raknet implementation to use
   raknetBackend: 'raknet-native',
   // If using JS implementation of RakNet, should we use workers? (This only affects the client)
-  useRaknetWorkers: true
+  useRaknetWorkers: true,
+
+  // server: What compression algorithm to use by default, either `none`, `deflate` or `snappy`
+  compressionAlgorithm: 'deflate',
+  // server and client: On Deflate, what compression level to use, between 1 and 9
+  compressionLevel: 7,
+  // server: If true, only compress if a payload is larger than compressionThreshold
+  compressionThreshold: 512
 }
 
 function validateOptions (options) {
@@ -34,7 +41,6 @@ function validateOptions (options) {
   if (options.protocolVersion < MIN_VERSION) {
     throw new Error(`Protocol version < ${MIN_VERSION} : ${options.protocolVersion}, too old`)
   }
-  this.compressionLevel = options.compressionLevel || 7
   if (options.useNativeRaknet === true) options.raknetBackend = 'raknet-native'
   if (options.useNativeRaknet === false) options.raknetBackend = 'jsp-raknet'
 }

--- a/src/rak.js
+++ b/src/rak.js
@@ -24,14 +24,15 @@ module.exports = (backend) => {
 }
 
 class RakNativeClient extends EventEmitter {
-  constructor (options) {
+  constructor (options, client) {
     super()
     this.connected = false
     this.onConnected = () => { }
     this.onCloseConnection = () => { }
     this.onEncapsulated = () => { }
 
-    this.raknet = new Client(options.host, options.port, { protocolVersion: 10 })
+    const protocolVersion = client?.versionGreaterThanOrEqualTo('1.19.30') ? 11 : 10
+    this.raknet = new Client(options.host, options.port, { protocolVersion })
     this.raknet.on('encapsulated', ({ buffer, address }) => {
       if (this.connected) { // Discard packets that are queued to be sent to us after close
         this.onEncapsulated(buffer, address)
@@ -86,7 +87,7 @@ class RakNativeServer extends EventEmitter {
     this.onEncapsulated = () => { }
     this.raknet = new Server(options.host, options.port, {
       maxConnections: options.maxPlayers || 3,
-      protocolVersion: 10,
+      protocolVersion: server.versionLessThan('1.19.30') ? 10 : 11,
       message: server.getAdvertisement().toBuffer()
     })
     this.onClose = () => {}

--- a/src/server.js
+++ b/src/server.js
@@ -3,7 +3,6 @@ const { createDeserializer, createSerializer } = require('./transforms/serialize
 const { Player } = require('./serverPlayer')
 const { sleep } = require('./datatypes/util')
 const { ServerAdvertisement } = require('./server/advertisement')
-const { Framer, DeflateFramer, SnappyFramer } = require('./transforms/framer')
 const Options = require('./options')
 const debug = globalThis.isElectron ? console.debug : require('debug')('minecraft-protocol')
 
@@ -29,16 +28,13 @@ class Server extends EventEmitter {
 
   setCompressor (algorithm, level = 1, threshold = 256) {
     if (algorithm === 'none') {
-      this.framer = Framer
       this.compressionAlgorithm = 'none'
       this.compressionLevel = 0
     } else if (algorithm === 'deflate') {
-      this.framer = DeflateFramer
       this.compressionAlgorithm = 'deflate'
       this.compressionLevel = level
       this.compressionThreshold = threshold
     } else if (algorithm === 'snappy') {
-      this.framer = SnappyFramer
       this.compressionAlgorithm = 'snappy'
       this.compressionLevel = level
       this.compressionThreshold = threshold
@@ -86,7 +82,7 @@ class Server extends EventEmitter {
       debug(`ignoring packet from unknown inet addr: ${address}`)
       return
     }
-    client.handle(buffer)
+    process.nextTick(() => client.handle(buffer))
   }
 
   getAdvertisement () {

--- a/src/server/advertisement.js
+++ b/src/server/advertisement.js
@@ -6,24 +6,26 @@ class ServerAdvertisement {
   playersOnline = 0
   playersMax = 5
   gamemode = 'Creative'
-  serverId = '0'
+  serverId = Date.now().toString()
   gamemodeId = 1
-  port = undefined
+  portV4 = undefined
   portV6 = undefined
 
-  constructor (obj, version = CURRENT_VERSION) {
+  constructor (obj, port, version = CURRENT_VERSION) {
     if (obj?.name) obj.motd = obj.name
     this.protocol = Versions[version]
     this.version = version
+    this.portV4 = port
+    this.portV6 = port
     Object.assign(this, obj)
   }
 
   fromString (str) {
-    const [header, motd, protocol, version, playersOnline, playersMax, serverId, levelName, gamemode, gamemodeId, port, portV6] = str.split(';')
-    Object.assign(this, { header, motd, protocol, version, playersOnline, playersMax, serverId, levelName, gamemode, gamemodeId, port, portV6 })
-    for (const numeric of ['playersOnline', 'playersMax', 'gamemodeId', 'port', 'portV6']) {
+    const [header, motd, protocol, version, playersOnline, playersMax, serverId, levelName, gamemode, gamemodeId, portV4, portV6] = str.split(';')
+    Object.assign(this, { header, motd, protocol, version, playersOnline, playersMax, serverId, levelName, gamemode, gamemodeId, portV4, portV6 })
+    for (const numeric of ['playersOnline', 'playersMax', 'gamemodeId', 'portV4', 'portV6']) {
       if (this[numeric] !== undefined) {
-        this[numeric] = parseInt(this[numeric])
+        this[numeric] = this[numeric] ? parseInt(this[numeric]) : null
       }
     }
     return this
@@ -39,13 +41,20 @@ class ServerAdvertisement {
       this.playersMax,
       this.serverId,
       this.levelName,
-      this.gamemode
+      this.gamemode,
+      this.gamemodeId,
+      this.portV4,
+      this.portV6,
+      '0'
     ].join(';') + ';'
   }
 
   toBuffer (version) {
     const str = this.toString(version)
-    return Buffer.concat([Buffer.from([0, str.length]), Buffer.from(str)])
+    const buf = Buffer.alloc(2 + str.length)
+    buf.writeUInt16BE(str.length, 0)
+    buf.write(str, 2)
+    return buf
   }
 }
 

--- a/src/serverPlayer.js
+++ b/src/serverPlayer.js
@@ -28,7 +28,7 @@ class Player extends Connection {
     }
 
     // Compression is server-wide
-    this.Framer = this.server.framer
+    this.compressionAlgorithm = this.server.compressionAlgorithm
     this.compressionLevel = this.server.compressionLevel
     this.compressionThreshold = this.server.compressionThreshold
 

--- a/src/serverPlayer.js
+++ b/src/serverPlayer.js
@@ -4,7 +4,6 @@ const { serialize, isDebug } = require('./datatypes/util')
 const { KeyExchange } = require('./handshake/keyExchange')
 const Login = require('./handshake/login')
 const LoginVerify = require('./handshake/loginVerify')
-const fs = require('fs')
 const debug = require('debug')('minecraft-protocol')
 
 class Player extends Connection {
@@ -15,7 +14,6 @@ class Player extends Connection {
     this.deserializer = server.deserializer
     this.connection = connection
     this.options = server.options
-    this.compressionLevel = server.compressionLevel
 
     KeyExchange(this, server, server.options)
     Login(this, server, server.options)
@@ -28,10 +26,41 @@ class Player extends Connection {
       this.inLog = (...args) => debug('S ->', ...args)
       this.outLog = (...args) => debug('S <-', ...args)
     }
+
+    // Compression is server-wide
+    this.Framer = this.server.framer
+    this.compressionLevel = this.server.compressionLevel
+    this.compressionThreshold = this.server.compressionThreshold
+
+    this._sentNetworkSettings = false // 1.19.30+
   }
 
   getUserData () {
     return this.userData
+  }
+
+  sendNetworkSettings () {
+    this.write('network_settings', {
+      compression_threshold: this.server.compressionThreshold,
+      compression_algorithm: this.server.compressionAlgorithm,
+      client_throttle: false,
+      client_throttle_threshold: 0,
+      client_throttle_scalar: 0
+    })
+    this._sentNetworkSettings = true
+  }
+
+  handleClientProtocolVersion (clientVersion) {
+    if (this.server.options.protocolVersion) {
+      if (this.server.options.protocolVersion < clientVersion) {
+        this.sendDisconnectStatus('failed_spawn') // client too new
+        return false
+      }
+    } else if (clientVersion < Options.MIN_VERSION) {
+      this.sendDisconnectStatus('failed_client') // client too old
+      return false
+    }
+    return true
   }
 
   onLogin (packet) {
@@ -39,13 +68,7 @@ class Player extends Connection {
     this.emit('loggingIn', body)
 
     const clientVer = body.params.protocol_version
-    if (this.server.options.protocolVersion) {
-      if (this.server.options.protocolVersion < clientVer) {
-        this.sendDisconnectStatus('failed_spawn')
-        return
-      }
-    } else if (clientVer < Options.MIN_VERSION) {
-      this.sendDisconnectStatus('failed_client')
+    if (!this.handleClientProtocolVersion(clientVer)) {
       return
     }
 
@@ -125,15 +148,24 @@ class Player extends Connection {
       var des = this.server.deserializer.parsePacketBuffer(packet) // eslint-disable-line
     } catch (e) {
       this.disconnect('Server error')
-      fs.writeFile(`packetdump_${this.connection.address}_${Date.now()}.bin`, packet)
+      debug('Dropping packet from', this.connection.address, e)
       return
     }
 
     this.inLog?.(des.data.name, serialize(des.data.params).slice(0, 200))
 
     switch (des.data.name) {
+      // This is the first packet on 1.19.30 & above
+      case 'request_network_settings':
+        if (this.handleClientProtocolVersion(des.data.params.client_protocol)) {
+          this.sendNetworkSettings()
+          this.compressionLevel = this.server.compressionLevel
+        }
+        return
+      // Below 1.19.30, this is the first packet.
       case 'login':
         this.onLogin(des)
+        if (!this._sentNetworkSettings) this.sendNetworkSettings()
         return
       case 'client_to_server_handshake':
         // Emit the 'join' event

--- a/src/transforms/serializer.js
+++ b/src/transforms/serializer.js
@@ -4,12 +4,7 @@ const { join } = require('path')
 
 class Parser extends FullPacketParser {
   parsePacketBuffer (buffer) {
-    try {
-      return super.parsePacketBuffer(buffer)
-    } catch (e) {
-      console.error('While decoding', buffer.toString('hex'))
-      throw e
-    }
+    return super.parsePacketBuffer(buffer)
   }
 
   verify (deserialized, serializer) {

--- a/test/internal.js
+++ b/test/internal.js
@@ -201,14 +201,14 @@ async function requestChunks (version, x, z, radius) {
 }
 
 async function timedTest (version, timeout = 1000 * 220) {
-  await waitFor((res) => {
+  await waitFor((resolve, reject) => {
     // mocha eats up stack traces...
-    startTest(version, res).catch(console.error)
+    startTest(version, resolve).catch(reject)
   }, timeout, () => {
     throw Error('timed out')
   })
   console.info('✔ ok')
 }
 
-// if (!module.parent) timedTest('1.19.10')
+if (!module.parent) timedTest('1.19.10')
 module.exports = { startTest, timedTest, requestChunks }

--- a/test/internal.js
+++ b/test/internal.js
@@ -210,5 +210,5 @@ async function timedTest (version, timeout = 1000 * 220) {
   console.info('✔ ok')
 }
 
-if (!module.parent) timedTest('1.19.10')
+// if (!module.parent) timedTest('1.19.10')
 module.exports = { startTest, timedTest, requestChunks }

--- a/test/proxy.js
+++ b/test/proxy.js
@@ -1,7 +1,7 @@
 const { createClient, Server, Relay } = require('bedrock-protocol')
 const { sleep, waitFor } = require('../src/datatypes/util')
 
-function proxyTest (version, raknetBackend = 'raknet-node', timeout = 1000 * 40) {
+function proxyTest (version, raknetBackend = 'raknet-native', timeout = 1000 * 40) {
   console.log('with raknet backend', raknetBackend)
   return waitFor(async res => {
     const SERVER_PORT = 19000 + ((Math.random() * 100) | 0)

--- a/test/proxy.js
+++ b/test/proxy.js
@@ -60,8 +60,8 @@ function proxyTest (version, raknetBackend = 'raknet-node', timeout = 1000 * 40)
   }, timeout, () => { throw Error('timed out') })
 }
 
-if (!module.parent) {
-  proxyTest('1.16.220', 'raknet-native')
-}
+// if (!module.parent) {
+//   proxyTest('1.16.220', 'raknet-native')
+// }
 
 module.exports = { proxyTest }

--- a/tools/startVanillaServer.js
+++ b/tools/startVanillaServer.js
@@ -87,6 +87,8 @@ function run (inheritStdout = true) {
   return cp.spawn(exe, inheritStdout ? { stdio: 'inherit' } : {})
 }
 
+let lastHandle
+
 // Run the server
 async function startServer (version, onStart, options = {}) {
   const os = process.platform === 'win32' ? 'win' : process.platform
@@ -95,7 +97,7 @@ async function startServer (version, onStart, options = {}) {
   }
   await download(os, version, options.path)
   configure(options)
-  const handle = run(!onStart)
+  const handle = lastHandle = run(!onStart)
   handle.on('error', (...a) => {
     console.warn('*** THE MINECRAFT PROCESS CRASHED ***', a)
     handle.kill('SIGKILL')
@@ -126,9 +128,12 @@ async function startServerAndWait (version, withTimeout, options) {
 
 async function startServerAndWait2 (version, withTimeout, options) {
   try {
-    return await startServerAndWait(version, withTimeout, options)
+    return await startServerAndWait(version, 1000 * 60, options)
   } catch (e) {
-    console.log(e, 'tring once more to start server...')
+    console.log(e)
+    console.log('^ Tring once more to start server in 10 seconds...')
+    lastHandle?.kill()
+    await new Promise(resolve => setTimeout(resolve, 10000))
     process.chdir(__dirname)
     fs.rmSync('bds-' + version, { recursive: true })
     return await startServerAndWait(version, withTimeout, options)


### PR DESCRIPTION
* Support configurable compressor for mc versions >= 1.19.30
  * use `deflate` as default on server for packet sizes >= 512 bytes (TODO: if user specifies lower compression threshold than `network_settings` response maybe compressed too early, not documenting these new options until we fix this)
  * no support for Snappy with this PR (appears vanilla default is still zlib)
* Support updated 1.19.30 login flow with NetworkSettings as first packet
* Improve serialization error handling on client
* Update server broadcasting ad to include new fields introduced in #278 