### PR TITLE
Fix buffer length calculation in ServerAdvertisement

### DIFF
--- a/src/server/advertisement.js
+++ b/src/server/advertisement.js
@@ -51,8 +51,9 @@ class ServerAdvertisement {
 
   toBuffer (version) {
     const str = this.toString(version)
-    const buf = Buffer.alloc(2 + str.length)
-    buf.writeUInt16BE(str.length, 0)
+    const length = Buffer.byteLength(str)
+    const buf = Buffer.alloc(2 + length)
+    buf.writeUInt16BE(length, 0)
     buf.write(str, 2)
     return buf
   }


### PR DESCRIPTION
The `toBuffer` method in ServerAdvertisement currently assumes that the byte length of the advertisement string when written to the buffer will be the same as the length of the corresponding JavaScript string.
Since JS internally uses utf-16 strings, characters that are larger than one byte can result in multibyte sequences when converted to utf-8 by the `buffer.write` method. This can result in the last bytes of the string being cut off as they no longer fit into the allocated buffer.

To resolve this, `Buffer.byteLength` can be used to determine the utf-8 byte length of the string before allocating the buffer.