### PR TITLE
Make CI less flaky

### DIFF
--- a/src/options.js
+++ b/src/options.js
@@ -7,6 +7,10 @@ const CURRENT_VERSION = '1.19.30'
 
 const Versions = Object.fromEntries(mcData.versions.bedrock.filter(e => e.releaseType === 'release').map(e => [e.minecraftVersion, e.version]))
 
+// Skip some low priority versions (middle major) on Github Actions to allow faster CI
+const skippedVersionsOnGithubCI = ['1.16.210', '1.17.10', '1.17.30', '1.18.11', '1.19.10', '1.19.20']
+const testedVersions = process.env.CI ? Object.keys(Versions).filter(v => !skippedVersionsOnGithubCI.includes(v)) : Object.keys(Versions)
+
 const defaultOptions = {
   // https://minecraft.gamepedia.com/Protocol_version#Bedrock_Edition_2
   version: CURRENT_VERSION,
@@ -45,4 +49,4 @@ function validateOptions (options) {
   if (options.useNativeRaknet === false) options.raknetBackend = 'jsp-raknet'
 }
 
-module.exports = { defaultOptions, MIN_VERSION, CURRENT_VERSION, Versions, validateOptions }
+module.exports = { defaultOptions, MIN_VERSION, CURRENT_VERSION, Versions, validateOptions, testedVersions }

--- a/test/internal.js
+++ b/test/internal.js
@@ -4,6 +4,7 @@ const { ping } = require('../src/createClient')
 const { CURRENT_VERSION } = require('../src/options')
 const { join } = require('path')
 const { waitFor } = require('../src/datatypes/util')
+const { getPort } = require('./util')
 
 // First we need to dump some packets that a vanilla server would send a vanilla
 // client. Then we can replay those back in our custom server.
@@ -14,7 +15,7 @@ function prepare (version) {
 async function startTest (version = CURRENT_VERSION, ok) {
   await prepare(version)
   const Item = require('../types/Item')(version)
-  const port = 19130 + Math.floor(Math.random() * 100)
+  const port = await getPort()
   const server = new Server({ host: '0.0.0.0', port, version, offline: true })
 
   function getPath (packetPath) {

--- a/test/internal.test.js
+++ b/test/internal.test.js
@@ -1,14 +1,14 @@
 /* eslint-env jest */
 
 const { timedTest } = require('./internal')
-const { Versions } = require('../src/options')
+const { testedVersions } = require('../src/options')
 const { sleep } = require('../src/datatypes/util')
 
 describe('internal client/server test', function () {
-  const vcount = Object.keys(Versions).length
+  const vcount = testedVersions.length
   this.timeout(vcount * 80 * 1000)
 
-  for (const version in Versions) {
+  for (const version of testedVersions) {
     it('connects ' + version, async () => {
       console.debug(version)
       await timedTest(version)

--- a/test/proxy.js
+++ b/test/proxy.js
@@ -1,11 +1,12 @@
 const { createClient, Server, Relay } = require('bedrock-protocol')
 const { sleep, waitFor } = require('../src/datatypes/util')
+const { getPort } = require('./util')
 
 function proxyTest (version, raknetBackend = 'raknet-native', timeout = 1000 * 40) {
   console.log('with raknet backend', raknetBackend)
   return waitFor(async res => {
-    const SERVER_PORT = 19000 + ((Math.random() * 100) | 0)
-    const CLIENT_PORT = 19000 + ((Math.random() * 100) | 0)
+    const SERVER_PORT = await getPort()
+    const CLIENT_PORT = await getPort()
     const server = new Server({
       host: '0.0.0.0', // optional
       port: SERVER_PORT, // optional

--- a/test/proxy.test.js
+++ b/test/proxy.test.js
@@ -1,13 +1,13 @@
 /* eslint-env jest */
 const { proxyTest } = require('./proxy')
-const { Versions } = require('../src/options')
+const { testedVersions } = require('../src/options')
 const { sleep } = require('../src/datatypes/util')
 
 describe('proxies client/server', function () {
-  const vcount = Object.keys(Versions).length
+  const vcount = testedVersions.length
   this.timeout(vcount * 30 * 1000)
 
-  for (const version in Versions) {
+  for (const version of testedVersions) {
     it('proxies ' + version, async () => {
       console.debug(version)
       await proxyTest(version)

--- a/test/proxy.test.js
+++ b/test/proxy.test.js
@@ -11,7 +11,7 @@ describe('proxies client/server', function () {
     it('proxies ' + version, async () => {
       console.debug(version)
       await proxyTest(version)
-      await sleep(5000)
+      await sleep(1000)
       console.debug('Done', version)
     })
   }

--- a/test/util.js
+++ b/test/util.js
@@ -1,0 +1,12 @@
+const net = require('net')
+
+const getPort = () => new Promise(resolve => {
+  const server = net.createServer()
+  server.listen(0, '127.0.0.1')
+  server.on('listening', () => {
+    const { port } = server.address()
+    server.close(() => resolve(port))
+  })
+})
+
+module.exports = { getPort }

--- a/test/vanilla.js
+++ b/test/vanilla.js
@@ -2,17 +2,19 @@
 const vanillaServer = require('../tools/startVanillaServer')
 const { Client } = require('../src/client')
 const { waitFor } = require('../src/datatypes/util')
+const { getPort } = require('./util')
 
 async function test (version) {
   const ChunkColumn = require('bedrock-provider').chunk('bedrock_' + (version.includes('1.19') ? '1.18.30' : version)) // TODO: Fix prismarine-chunk
 
   // Start the server, wait for it to accept clients, throws on timeout
-  const handle = await vanillaServer.startServerAndWait2(version, 1000 * 220)
+  const port = await getPort()
+  const handle = await vanillaServer.startServerAndWait2(version, 1000 * 220, { 'server-port': port })
   console.log('Started server')
 
   const client = new Client({
     host: '127.0.0.1',
-    port: 19130,
+    port,
     username: 'Notch',
     version,
     raknetBackend: 'raknet-native',

--- a/test/vanilla.test.js
+++ b/test/vanilla.test.js
@@ -1,14 +1,14 @@
 /* eslint-env jest */
 
 const { clientTest } = require('./vanilla')
-const { Versions } = require('../src/options')
+const { testedVersions } = require('../src/options')
 const { sleep } = require('../src/datatypes/util')
 
 describe('vanilla server test', function () {
-  const vcount = Object.keys(Versions).length
+  const vcount = testedVersions.length
   this.timeout(vcount * 80 * 1000)
 
-  for (const version in Versions) {
+  for (const version of testedVersions) {
     it('client spawns ' + version, async () => {
       await clientTest(version)
       await sleep(100)

--- a/tools/genPacketDumps.js
+++ b/tools/genPacketDumps.js
@@ -6,6 +6,7 @@ const { Client } = require('../src/client')
 const { serialize, waitFor, getFiles } = require('../src/datatypes/util')
 const { CURRENT_VERSION } = require('../src/options')
 const { join } = require('path')
+const { getPort } = require('../test/util')
 
 function hasDumps (version) {
   const root = join(__dirname, `../data/${version}/sample/packets/`)
@@ -19,7 +20,7 @@ let loop
 
 async function dump (version, force = true) {
   const random = (Math.random() * 1000) | 0
-  const [port, v6] = [19132 + random, 19133 + random]
+  const [port, v6] = [await getPort(), await getPort()]
 
   console.log('Starting dump server', version)
   const handle = await vanillaServer.startServerAndWait2(version || CURRENT_VERSION, 1000 * 120, { 'server-port': port, 'server-portv6': v6 })

--- a/tools/startVanillaServer.js
+++ b/tools/startVanillaServer.js
@@ -49,7 +49,7 @@ async function download (os, version, path = 'bds-') {
 
   for (let i = 0; i < 8; i++) { // Check for the latest server build for version (major.minor.patch.BUILD)
     const u = url(os, `${verStr}.${String(i).padStart(2, '0')}`)
-    debug('Opening', u)
+    debug('Opening', u, Date.now())
     const ret = await head(u)
     if (ret.statusCode === 200) {
       found = u
@@ -121,7 +121,7 @@ async function startServerAndWait (version, withTimeout, options) {
     handle = await startServer(version, res, options)
   }, withTimeout, () => {
     handle?.kill()
-    throw new Error('Server did not start on time ' + withTimeout)
+    throw new Error(`Server did not start on time (${withTimeout}ms, now ${Date.now()})`)
   })
   return handle
 }


### PR DESCRIPTION
* Reduce versions tested so Github CI takes ~5-6 min instead of ~10-11 min by only testing first and last release of a major version (local npm test still runs everything)
* Get port from OS like minecraft-protocol / mineflayer
* Maybe fix #216