### PR TITLE
Add profilesFolder to ClientOptions type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -45,6 +45,8 @@ declare module "bedrock-protocol" {
     conLog?
     // used to join a Realm instead of supplying a host/port
     realms?: RealmsOptions
+    // the path to store authentication caches, defaults to .minecraft
+    profilesFolder?: string | false
   }
 
   export interface ServerOptions extends Options {


### PR DESCRIPTION
Noticed this was missing from the ClientOptions type even though it's already built in and supported.
I have been using it for about a week without any issue when forcing the type so figured I'd make a quick PR to fix it.