### PR TITLE
Update Type for authTitle

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -174,7 +174,7 @@ declare module 'bedrock-protocol' {
     // Skip authentication for connecting clients?
     offline?: false
     // Specifies which game edition to sign in as to the destination server. Optional, but some servers verify this.
-    authTitle?: title | string
+    authTitle?: string
     // Where to proxy requests to.
     destination: {
       realms?: RealmsOptions


### PR DESCRIPTION
authType is a string. It was corrected in commit 8507286895b6c1f0382d70f398f3127bd473b14c but this particular change was overlooked.

This solves the error:

node_modules/bedrock-protocol/index.d.ts:177:17 - error TS2304: Cannot find name 'title'.

177     authTitle?: title | string
                    ~~~~~


Found 1 error in node_modules/bedrock-protocol/index.d.ts:177