### PR TITLE
Mark listen and close functions as async

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -162,8 +162,8 @@ declare module 'bedrock-protocol' {
 
     constructor(options: Options)
 
-    listen(host?: string, port?: number): void
-    close(disconnectReason?: string): void
+    listen(host?: string, port?: number): Promise<void>
+    close(disconnectReason?: string): Promise<void>
 
     on(event: 'connect', cb: (client: Player) => void): any
   }


### PR DESCRIPTION
`Server` has `listen` and `stop` functions that return `void` instead of `Promise<void>` in `index.d.ts`, which makes error handling non-obvious