### PR TITLE
Add `authflow` option

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -23,6 +23,7 @@ Returns a `Client` instance and connects to the server.
 | raknetBackend | *optional* | Specifies the raknet implementation to use. Possible options are 'raknet-native' (default, original C++ implementation), 'jsp-raknet' (JS port), and 'raknet-node' (Rust port). Please note when using the non-JS implementation you may the need approporate build tools on your system (for example a C++ or Rust compiler). |
 | compressionLevel | *optional* | What zlib compression level to use, default to **7** |
 | batchingInterval | *optional* | How frequently, in milliseconds to flush and write the packet queue (default: 20ms) |
+| authflow | *optional* | You can optionally provide your own [Authflow](https://github.com/PrismarineJS/prismarine-auth#authflow) instance using this option. If not provided, the client will create one automatically and passthrough options from the client. |
 | realms | *optional* | An object which should contain one of the following properties: `realmId`, `realmInvite`, `pickRealm`. When defined will attempt to join a Realm without needing to specify host/port. **The authenticated account must either own the Realm or have been invited to it** |
 | realms.realmId | *optional* | The id of the Realm to join. |
 | realms.realmInvite | *optional* | The invite link/code of the Realm to join. |

--- a/src/client/auth.js
+++ b/src/client/auth.js
@@ -65,8 +65,7 @@ async function realmAuthenticate (options) {
 async function authenticate (client, options) {
   validateOptions(options)
   try {
-    const authflow = options.authflow
-    const chains = await authflow.getMinecraftBedrockToken(client.clientX509).catch(e => {
+    const chains = await options.authflow.getMinecraftBedrockToken(client.clientX509).catch(e => {
       if (options.password) console.warn('Sign in failed, try removing the password field')
       throw e
     })

--- a/src/client/auth.js
+++ b/src/client/auth.js
@@ -14,12 +14,13 @@ function validateOptions (options) {
     options.deviceType = 'Nintendo'
     options.flow = 'live'
   }
+  if (!(options.authflow instanceof PrismarineAuth)) {
+    options.authflow = new PrismarineAuth(options.username, options.profilesFolder, options, options.onMsaCode)
+  }
 }
 
 async function realmAuthenticate (options) {
   validateOptions(options)
-
-  options.authflow = new PrismarineAuth(options.username, options.profilesFolder, options, options.onMsaCode)
 
   const api = RealmAPI.from(options.authflow, 'bedrock')
 
@@ -64,7 +65,7 @@ async function realmAuthenticate (options) {
 async function authenticate (client, options) {
   validateOptions(options)
   try {
-    const authflow = options.authflow || new PrismarineAuth(options.username, options.profilesFolder, options, options.onMsaCode)
+    const authflow = options.authflow
     const chains = await authflow.getMinecraftBedrockToken(client.clientX509).catch(e => {
       if (options.password) console.warn('Sign in failed, try removing the password field')
       throw e


### PR DESCRIPTION
Allow users to specify their own [Authflow](https://github.com/PrismarineJS/prismarine-auth#authflow) instance. Useful if you have a project utilising prismarine-auth and want to share credentials / caching solutions. 