### PR TITLE
Update Minecraft wiki link to new domain

### DIFF
--- a/src/options.js
+++ b/src/options.js
@@ -12,7 +12,7 @@ const skippedVersionsOnGithubCI = ['1.16.210', '1.17.10', '1.17.30', '1.18.11', 
 const testedVersions = process.env.CI ? Object.keys(Versions).filter(v => !skippedVersionsOnGithubCI.includes(v)) : Object.keys(Versions)
 
 const defaultOptions = {
-  // https://minecraft.gamepedia.com/Protocol_version#Bedrock_Edition_2
+  // https://minecraft.wiki/w/Protocol_version#Bedrock_Edition_2
   version: CURRENT_VERSION,
   // client: If we should send SetPlayerInitialized to the server after getting play_status spawn.
   // if this is disabled, no 'spawn' event will be emitted, you should manually set


### PR DESCRIPTION
The Minecraft Fandom wiki has been forked to a new domain: minecraft.wiki. Learn more here: https://minecraft.wiki/w/Minecraft_Wiki:Moving_from_Fandom. This PR updates the old wiki link accordingly.