### PR TITLE
Fix Spelling mistake In types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -63,7 +63,7 @@ declare module 'bedrock-protocol' {
   }
 
   enum ClientStatus {
-    Disconected,
+    Disconnected,
     Authenticating,
     Initializing,
     Initialized


### PR DESCRIPTION
This pull request addresses a typo in the ClientStatus type definition. The value ClientStatus.Disconected has been corrected to ClientStatus.Disconnected.