### PR TITLE
Tick Sync is now deprecated

### DIFF
--- a/src/connection.js
+++ b/src/connection.js
@@ -39,6 +39,10 @@ class Connection extends EventEmitter {
     return this.options.protocolVersion >= (typeof version === 'string' ? Versions[version] : version)
   }
 
+  versionLessThanOrEqualTo (version) {
+    return this.options.protocolVersion <= (typeof version === 'string' ? Versions[version] : version)
+  }
+
   startEncryption (iv) {
     this.encryptionEnabled = true
     this.inLog?.('Started encryption', this.sharedSecret, iv)

--- a/src/createClient.js
+++ b/src/createClient.js
@@ -56,30 +56,7 @@ function connect (client) {
     })
 
     client.queue('client_cache_status', { enabled: false })
-    client.queue('tick_sync', { request_time: BigInt(Date.now()), response_time: 0n })
     sleep(500).then(() => client.queue('request_chunk_radius', { chunk_radius: client.viewDistance || 10 }))
-  })
-
-  // Send tick sync packets every 10 ticks
-  const keepAliveInterval = 10
-  const keepAliveIntervalBig = BigInt(keepAliveInterval)
-  let keepalive
-  client.tick = 0n
-  client.once('spawn', () => {
-    keepalive = setInterval(() => {
-      // Client fills out the request_time and the server does response_time in its reply.
-      client.queue('tick_sync', { request_time: client.tick, response_time: 0n })
-      client.tick += keepAliveIntervalBig
-    }, 50 * keepAliveInterval)
-
-    client.on('tick_sync', async packet => {
-      client.emit('heartbeat', packet.response_time)
-      client.tick = packet.response_time
-    })
-  })
-
-  client.once('close', () => {
-    clearInterval(keepalive)
   })
 }
 

--- a/src/createClient.js
+++ b/src/createClient.js
@@ -5,7 +5,6 @@ const assert = require('assert')
 const Options = require('./options')
 const advertisement = require('./server/advertisement')
 const auth = require('./client/auth')
-const { Connection } = require('./connection')
 
 /** @param {{ version?: number, host: string, port?: number, connectTimeout?: number, skipPing?: boolean }} options */
 function createClient(options) {

--- a/src/createClient.js
+++ b/src/createClient.js
@@ -7,11 +7,11 @@ const advertisement = require('./server/advertisement')
 const auth = require('./client/auth')
 
 /** @param {{ version?: number, host: string, port?: number, connectTimeout?: number, skipPing?: boolean }} options */
-function createClient(options) {
+function createClient (options) {
   assert(options)
   const client = new Client({ port: 19132, followPort: !options.realms, ...options, delayedInit: true })
 
-  function onServerInfo() {
+  function onServerInfo () {
     client.on('connect_allowed', () => connect(client))
     if (options.skipPing) {
       client.init()
@@ -38,7 +38,7 @@ function createClient(options) {
   return client
 }
 
-function connect(client) {
+function connect (client) {
   // Actually connect
   client.connect()
 
@@ -88,7 +88,7 @@ function connect(client) {
   }
 }
 
-async function ping({ host, port }) {
+async function ping ({ host, port }) {
   const con = new RakClient({ host, port })
 
   try {


### PR DESCRIPTION
First, Tick Sync is now deprecated in v1.21.0

Second, no actual clients used this packet and it was never required in apart of the login sequence.

A [PR](https://github.com/Mojang/bedrock-protocol-docs/pull/7/files#diff-7dbc2f93cf0db3f6afae4a0c65236ae3ec03b56c279f72bf3a9e5062746af837R42) in Mojang's Bedrock Protocol Docs suggests the packet being deprecated.