### PR TITLE
Fix example in README.md for 1.21

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ client.on('text', (packet) => { // Listen for chat messages from the server and 
   if (packet.source_name != client.username) {
     client.queue('text', {
       type: 'chat', needs_translation: false, source_name: client.username, xuid: '', platform_chat_id: '',
-      message: `${packet.source_name} said: ${packet.message} on ${new Date().toLocaleString()}`
+      message: `${packet.source_name} said: ${packet.message} on ${new Date().toLocaleString()}`, filtered_message: ''
     })
   }
 })

--- a/README.md
+++ b/README.md
@@ -54,8 +54,8 @@ const client = bedrock.createClient({
 client.on('text', (packet) => { // Listen for chat messages from the server and echo them back.
   if (packet.source_name != client.username) {
     client.queue('text', {
-      type: 'chat', needs_translation: false, source_name: client.username, xuid: '', platform_chat_id: '',
-      message: `${packet.source_name} said: ${packet.message} on ${new Date().toLocaleString()}`, filtered_message: ''
+      type: 'chat', needs_translation: false, source_name: client.username, xuid: '', platform_chat_id: '', filtered_message: '',
+      message: `${packet.source_name} said: ${packet.message} on ${new Date().toLocaleString()}`
     })
   }
 })

--- a/examples/client/client.js
+++ b/examples/client/client.js
@@ -10,7 +10,7 @@ const client = bedrock.createClient({
 client.on('text', (packet) => { // Listen for chat messages and echo them back.
   if (packet.source_name != client.username) {
     client.queue('text', {
-      type: 'chat', needs_translation: false, source_name: client.username, xuid: '', platform_chat_id: '',
+      type: 'chat', needs_translation: false, source_name: client.username, xuid: '', platform_chat_id: '', filtered_message: '',
       message: `${packet.source_name} said: ${packet.message} on ${new Date().toLocaleString()}`
     })
   }


### PR DESCRIPTION
I tried using the client example in the README.md file, but it is broken in 1.21, I fixed it by adding filtered_message with an empty string to the part where it sends a text packet