### PR TITLE
Dynamic compression & batch header

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -26,6 +26,7 @@ class Client extends Connection {
     this.compressionAlgorithm = this.versionGreaterThanOrEqualTo('1.19.30') ? 'none' : 'deflate'
     this.compressionThreshold = 512
     this.compressionLevel = this.options.compressionLevel
+    this.batchHeader = 0xfe
 
     if (isDebug) {
       this.inLog = (...args) => debug('C ->', ...args)

--- a/src/connection.js
+++ b/src/connection.js
@@ -153,7 +153,7 @@ class Connection extends EventEmitter {
 
   // These are callbacks called from encryption.js
   onEncryptedPacket = (buf) => {
-    const packet = Buffer.concat([Buffer.from([0xfe]), buf]) // add header
+    const packet = this.batchHeader ? Buffer.concat([Buffer.from([this.batchHeader]), buf]) : buf
     this.sendMCPE(packet)
   }
 
@@ -165,7 +165,7 @@ class Connection extends EventEmitter {
   }
 
   handle (buffer) { // handle encapsulated
-    if (buffer[0] === 0xfe) { // wrapper
+    if (!this.batchHeader || buffer[0] === this.batchHeader) { // wrapper
       if (this.encryptionEnabled) {
         this.decrypt(buffer.slice(1))
       } else {

--- a/src/server.js
+++ b/src/server.js
@@ -24,6 +24,7 @@ class Server extends EventEmitter {
     this.clients = {}
     this.clientCount = 0
     this.conLog = debug
+    this.batchHeader = 0xfe
 
     this.setCompressor(this.options.compressionAlgorithm, this.options.compressionLevel, this.options.compressionThreshold)
   }
@@ -44,16 +45,19 @@ class Server extends EventEmitter {
       case 'none':
         this.compressionAlgorithm = 'none'
         this.compressionLevel = 0
+        this.compressionHeader = 255
         break
       case 'deflate':
         this.compressionAlgorithm = 'deflate'
         this.compressionLevel = level
         this.compressionThreshold = threshold
+        this.compressionHeader = 0
         break
       case 'snappy':
         this.compressionAlgorithm = 'snappy'
         this.compressionLevel = level
         this.compressionThreshold = threshold
+        this.compressionHeader = 1
         break
       default:
         throw new Error(`Unknown compression algorithm: ${algorithm}`)

--- a/src/serverPlayer.js
+++ b/src/serverPlayer.js
@@ -28,10 +28,12 @@ class Player extends Connection {
       this.outLog = (...args) => debug('<- S', ...args)
     }
 
+    this.batchHeader = this.server.batchHeader
     // Compression is server-wide
     this.compressionAlgorithm = this.server.compressionAlgorithm
     this.compressionLevel = this.server.compressionLevel
     this.compressionThreshold = this.server.compressionThreshold
+    this.compressionHeader = this.server.compressionHeader
 
     this._sentNetworkSettings = false // 1.19.30+
   }


### PR DESCRIPTION
When encoding packets currently bedrock-protocol hardcodes the header to 0 (deflate), this PR allows for the header to be set based on the chosen `compressionAlgorithm` and uses the header 255 if the packet does not need compressing.

Also parameterised the batch header as Nethernet does not need this.