### PR TITLE
Server does not properly remove connections from clients list

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -94,7 +94,7 @@ class Server extends EventEmitter {
 
     delete this.clients[inetAddr]?.connection // Prevent close loop
     this.clients[inetAddr?.address ?? inetAddr]?.close()
-    delete this.clients[inetAddr]
+    delete this.clients[inetAddr?.address]
     this.clientCount--
   }
 

--- a/src/server.js
+++ b/src/server.js
@@ -90,11 +90,9 @@ class Server extends EventEmitter {
   }
 
   onCloseConnection = (conn, reason) => {
-    this.conLog('Connection closed: ', conn?.address, reason)
-
-    delete this.clients[conn]?.connection // Prevent close loop
-    this.clients[conn?.address ?? conn]?.close()
-    delete this.clients[conn?.address]
+    this.conLog('Connection closed: ', conn.address, reason)
+    this.clients[conn.address]?.close()
+    delete this.clients[conn.address]
     this.clientCount--
   }
 

--- a/src/server.js
+++ b/src/server.js
@@ -89,12 +89,12 @@ class Server extends EventEmitter {
     this.emit('connect', player)
   }
 
-  onCloseConnection = (inetAddr, reason) => {
-    this.conLog('Connection closed: ', inetAddr?.address, reason)
+  onCloseConnection = (conn, reason) => {
+    this.conLog('Connection closed: ', conn?.address, reason)
 
-    delete this.clients[inetAddr]?.connection // Prevent close loop
-    this.clients[inetAddr?.address ?? inetAddr]?.close()
-    delete this.clients[inetAddr?.address]
+    delete this.clients[conn]?.connection // Prevent close loop
+    this.clients[conn?.address ?? conn]?.close()
+    delete this.clients[conn?.address]
     this.clientCount--
   }
 


### PR DESCRIPTION
When creating a server using the code below, `this.clients` still retains players that has disconnected from said server after connecting and disconnecting.
```js
const bedrock = require('bedrock-protocol')
const server = bedrock.createServer({
  host: '0.0.0.0',
  port: 19132
})
server.on('connect', async player => {
  player.on('join', async (p) => { 
    console.log(player.connection.address, ' Connected')
    while(Object.keys(server.clients).includes(player.connection.address)){
      console.log('Connections: ' + Object.keys(server.clients).join(' '))
      await new Promise(r => setTimeout(r, 2000)) // Wait 2 seconds
    }
    console.log(player.connection + ' Disconnected')
  })
})
```
The expected console output here should be something similar to this:
```
127.0.0.1/12345Connected
Connections: 127.0.0.1/12345
Connections: 127.0.0.1/12345
[...]
Connections: 127.0.0.1/12345
Connections: 127.0.0.1/12345
127.0.0.1/12345Disconnected
```
But instead the console output is this:
```
127.0.0.1/12345Connected
Connections: 127.0.0.1/12345
Connections: 127.0.0.1/12345
Connections: 127.0.0.1/12345
[...]
```
Where the script never says the client disconnected and displays `Connections: 127.0.0.1/12345` indefinitely.