### PR TITLE
Skin Data Changes

### DIFF
--- a/src/handshake/login.js
+++ b/src/handshake/login.js
@@ -36,8 +36,6 @@ module.exports = (client, server, options) => {
   client.createClientUserChain = (privateKey) => {
     let payload = {
       ...skinData,
-      SkinGeometryDataEngineVersion: client.versionGreaterThanOrEqualTo('1.17.30') ? '' : undefined,
-
       ClientRandomId: Date.now(),
       CurrentInputMode: 1,
       DefaultInputMode: 1,
@@ -66,7 +64,7 @@ module.exports = (client, server, options) => {
       IsEditorMode: false,
       TrustedSkin: client.versionGreaterThanOrEqualTo('1.19.20') ? false : undefined,
       OverrideSkin: client.versionGreaterThanOrEqualTo('1.19.62') ? false : undefined,
-      CompatibleWithClientSideChunkGen: client.versionGreaterThanOrEqualTo('1.19.80') ? false : undefined,
+      CompatibleWithClientSideChunkGen: client.versionGreaterThanOrEqualTo('1.19.80') ? true : undefined,
 
       MaxViewDistance: client.versionGreaterThanOrEqualTo('1.21.42') ? 0 : undefined,
       MemoryTier: client.versionGreaterThanOrEqualTo('1.21.42') ? 0 : undefined,

--- a/src/handshake/login.js
+++ b/src/handshake/login.js
@@ -36,6 +36,7 @@ module.exports = (client, server, options) => {
   client.createClientUserChain = (privateKey) => {
     let payload = {
       ...skinData,
+
       ClientRandomId: Date.now(),
       CurrentInputMode: 1,
       DefaultInputMode: 1,
@@ -64,7 +65,7 @@ module.exports = (client, server, options) => {
       IsEditorMode: false,
       TrustedSkin: client.versionGreaterThanOrEqualTo('1.19.20') ? false : undefined,
       OverrideSkin: client.versionGreaterThanOrEqualTo('1.19.62') ? false : undefined,
-      CompatibleWithClientSideChunkGen: client.versionGreaterThanOrEqualTo('1.19.80') ? true : undefined,
+      CompatibleWithClientSideChunkGen: client.versionGreaterThanOrEqualTo('1.19.80') ? false : undefined,
 
       MaxViewDistance: client.versionGreaterThanOrEqualTo('1.21.42') ? 0 : undefined,
       MemoryTier: client.versionGreaterThanOrEqualTo('1.21.42') ? 0 : undefined,


### PR DESCRIPTION
SkinGeometryDataEngineVersion is automatically blank each time, even when the recent skin data has that value fulfilled.
(it's just useless for that to exist here when the skin JSON can include that data)

~Also, CompatibleWithClientSideChunkGen is always set to true by default on normal clients~ (changed due to older versions not retrieving biome_definition_list)