### PR TITLE
Fix publish workflow for trusted publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Set up Node.js
       uses: actions/setup-node@master
       with:
-        node-version: 14.0.0
+        node-version: 24
         registry-url: 'https://registry.npmjs.org'
     - run: npm install
     - id: publish


### PR DESCRIPTION
## Summary
- Update to JS-DevTools/npm-publish@v4
- Set node-version to 24 (trusted publishing requires npm >=11.5.1)
- Add registry-url for OIDC
- Fix publish condition for v4
- Remove NPM_AUTH_TOKEN (using OIDC now)

🤖 Generated with [Claude Code](https://claude.com/claude-code)