### PR TITLE
client: respond to network_stack_latency packets

### DIFF
--- a/src/createClient.js
+++ b/src/createClient.js
@@ -42,6 +42,13 @@ function connect (client) {
   // Actually connect
   client.connect()
 
+  // Echo network_stack_latency back so latency-tracking servers see the client as responsive (#643).
+  client.on('network_stack_latency', (packet) => {
+    if (packet.needs_response) {
+      client.queue('network_stack_latency', { timestamp: packet.timestamp, needs_response: false })
+    }
+  })
+
   client.once('resource_packs_info', (packet) => {
     client.write('resource_pack_client_response', {
       response_status: 'completed',


### PR DESCRIPTION
A vanilla client echoes network_stack_latency back to the server, but the client never did, so latency-measuring servers (and server-side anticheats that track the round-trip) see it as unresponsive and time it out. Echo each request straight back with the same timestamp.