### PR TITLE
docs: document command_request, and the two fields that changed at 1.21.130

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -162,6 +162,38 @@ Both Client and ServerPlayer classes have `write(name, params)` and `queue(name,
 
 You can use `.close()` to terminate a connection, and `.disconnect(reason)` to gracefully kick a connected client.
 
+### Running commands
+
+Send a `command_request` and correlate the server's `command_output` back to it with `origin.uuid`, which the server echoes:
+
+```js
+const { randomUUID } = require('crypto')
+
+const uuid = randomUUID()
+client.on('command_output', (packet) => {
+  if (packet.origin.uuid === uuid) console.log(packet.output)
+})
+
+client.queue('command_request', {
+  command: '/list',
+  origin: {
+    type: 'player',
+    uuid,
+    request_id: '',
+    player_entity_id: 0n // 1.26.x and above only, see below
+  },
+  internal: false,
+  version: 'latest' // see below
+})
+```
+
+Two fields are version dependent, and getting either wrong on 1.26.x produces a **terminating** `packet_violation_warning` whose reason reads `Command exceeds maximum size of 512 characters.` regardless of the actual cause — it is boilerplate, so don't read it as being about the command length:
+
+* `version` is a varint on 1.21.x and below, and a string from 1.21.130 onwards. On 1.26.x pass the string `'latest'`; numeric-looking values such as `'52'` are rejected.
+* `origin.player_entity_id` is behind a switch on 1.21.x and below (so a `player` origin omits it), but is an unconditional `li64` from 1.21.130 onwards. Omitting it there throws while serializing, before anything is sent.
+
+Note that `command_output.output_type` is a string from 1.21.130 onwards rather than the older enum, and on 1.26.x the complete-output value is spelled `'alloutput'` where the old enum called it `'all'`. Some commands, such as `/say`, produce no `command_output` for the sender at all, so don't await one.
+
 ### Protocol docs
 
 For documentation on the protocol, and packets/fields see the [the protocol doc](https://prismarinejs.github.io/minecraft-data/?v=bedrock_1.18.0&d=protocol) (the emitted event names are the Packet types in lower case without the "packet_" prefix). More information on syntax can be found in CONTRIBUTING.md. When sending a packet, you must fill out all of the required fields.


### PR DESCRIPTION
Adds a short "Running commands" section to `docs/API.md`.

`command_request` is a common thing to want and currently undocumented, and two of its fields changed shape at 1.21.130 in ways that are easy to get wrong. Worse, getting either wrong on 1.26.x produces a *terminating* `packet_violation_warning` whose reason is `Command exceeds maximum size of 512 characters.` no matter what actually went wrong — an empty command produces the same text — so the error actively points away from the cause.

That combination has cost several people real time in #679 and #682, including me: I spent a while convinced the `bedrock_1.26.x` schema was wrong and [said so publicly](https://github.com/PrismarineJS/bedrock-protocol/issues/679#issuecomment-5200176785) before capturing a real 1.26.40 client's bytes and finding the schema matches field for field. The actual problem was that I was sending `version: '52'` instead of `'latest'`. The correction, with the captured bytes and a self-contained repro, is [here](https://github.com/PrismarineJS/bedrock-protocol/issues/679#issuecomment-5208652187).

The two version-dependent fields:

* **`version`** — a varint on 1.21.x and below, a string from 1.21.130 onwards. On 1.26.x it must be the string `'latest'`; numeric-looking values like `'52'` are rejected.
* **`origin.player_entity_id`** — behind a switch on 1.21.x and below (a `player` origin omits it), an unconditional `li64` from 1.21.130 onwards. Omitting it there throws while serializing, before anything reaches the wire.

Both boundaries were read off the shipped `minecraft-data` schemas rather than guessed:

```
1.21.124 (proto 860)  version=varint  origin.type=mapper  player_entity_id=switch
1.21.130 (proto 898)  version=string  origin.type=string  player_entity_id=li64
1.26.0   (proto 924)  version=string  origin.type=string  player_entity_id=li64
```

The accept/reject behaviour was verified live against a vanilla BDS 1.26.30.5 with the stock schema unpatched: `'latest'` accepted (with a correlated `command_output`), `'52'` rejected, and a packet byte-identical to the accepted one except for that string is rejected — so nothing else is varying. `request_id` turns out not to matter either way. The `output_type` note (`'alloutput'` on 1.26.x where the old enum said `'all'`) was measured the same way, along with `'silent'` under `sendcommandfeedback=false`.

### Testing

Docs only — no code changes. `npm run lint` (the `pretest` gate) passes. I did **not** run `npm test`: it provisions and boots real vanilla servers, which didn't complete in this environment, and nothing here touches code paths it covers.

Happy to reword, shorten, or move this if you'd prefer it somewhere other than under `## Methods`.
