### PR TITLE
Fix modern authentication and relay compat; add 1.26.44 support

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -34,6 +34,8 @@ declare module 'bedrock-protocol' {
     viewDistance?: number
     // Specifies which game edition to sign in as. Optional, but some servers verify this.
     authTitle?: string
+    // Bedrock DeviceOS enum value. Derived from known authTitle values; required for custom titles.
+    deviceOS?: number
     // How long to wait in milliseconds while trying to connect to the server.
     connectTimeout?: number
     // whether to skip initial ping and immediately connect

--- a/src/client/auth.js
+++ b/src/client/auth.js
@@ -5,14 +5,33 @@ const debug = require('debug')('minecraft-protocol')
 const { uuidFrom } = require('../datatypes/util')
 const { RealmAPI } = require('prismarine-realms')
 
+// BDS validates that the login DeviceOS agrees with the platform used to
+// authenticate. Values are from the protocol DeviceOS enum.
+const deviceOSByAuthTitle = {
+  [Titles.MinecraftAndroid]: 1,
+  [Titles.MinecraftIOS]: 2,
+  [Titles.MinecraftPlaystation]: 11,
+  [Titles.MinecraftNintendoSwitch]: 12
+}
+
 function validateOptions (options) {
   if (!options.profilesFolder) {
     options.profilesFolder = path.join(minecraftFolderPath, 'nmp-cache')
+  }
+  if (options.offline) {
+    options.deviceOS ??= options.skinData?.DeviceOS ?? 7
+    return
   }
   if (options.authTitle === undefined) {
     options.authTitle = Titles.MinecraftNintendoSwitch
     options.deviceType = 'Nintendo'
     options.flow = 'live'
+  }
+  if (options.deviceOS === undefined) {
+    options.deviceOS = options.skinData?.DeviceOS ?? deviceOSByAuthTitle[options.authTitle]
+  }
+  if (options.deviceOS === undefined) {
+    throw new Error('deviceOS is required when authTitle does not identify a known Minecraft platform')
   }
 }
 
@@ -99,6 +118,7 @@ async function authenticate (client, options) {
  * Creates an offline session for the client
  */
 function createOfflineSession (client, options) {
+  validateOptions(options)
   if (!options.username) throw Error('Must specify a valid username')
   const profile = {
     name: options.username,

--- a/src/client/auth.js
+++ b/src/client/auth.js
@@ -18,17 +18,13 @@ function validateOptions (options) {
   if (!options.profilesFolder) {
     options.profilesFolder = path.join(minecraftFolderPath, 'nmp-cache')
   }
-  if (options.offline) {
-    options.deviceOS ??= options.skinData?.DeviceOS ?? 7
-    return
-  }
   if (options.authTitle === undefined) {
     options.authTitle = Titles.MinecraftNintendoSwitch
     options.deviceType = 'Nintendo'
     options.flow = 'live'
   }
   if (options.deviceOS === undefined) {
-    options.deviceOS = options.skinData?.DeviceOS ?? deviceOSByAuthTitle[options.authTitle]
+    options.deviceOS = deviceOSByAuthTitle[options.authTitle]
   }
   if (options.deviceOS === undefined) {
     throw new Error('deviceOS is required when authTitle does not identify a known Minecraft platform')

--- a/src/datatypes/compiler-minecraft.js
+++ b/src/datatypes/compiler-minecraft.js
@@ -50,9 +50,14 @@ Read.maybeIncompleteArray = ['parametrizable', (compiler, { countType, type }) =
   const data = []
   let size = countSize
   for (let i = 0; i < count && offset + size < buffer.length; i++) {
-    const elem = ${compiler.callType(type, 'offset + size')}
-    data.push(elem.value)
-    size += elem.size
+    try {
+      const elem = ${compiler.callType(type, 'offset + size')}
+      data.push(elem.value)
+      size += elem.size
+    } catch (error) {
+      if (error.name !== "PartialReadError") throw error
+      break
+    }
   }
   return { value: data, size }
 `.trim())

--- a/src/datatypes/minecraft.js
+++ b/src/datatypes/minecraft.js
@@ -157,9 +157,14 @@ function readMaybeIncompleteArray (buffer, offset, typeArgs) {
   let cursor = offset + count.size
 
   for (let i = 0; i < count.value && cursor < buffer.length; i++) {
-    const result = this.read(buffer, cursor, type, {})
-    elements.push(result.value)
-    cursor += result.size
+    try {
+      const result = this.read(buffer, cursor, type, {})
+      elements.push(result.value)
+      cursor += result.size
+    } catch (error) {
+      if (error.name !== 'PartialReadError') throw error
+      break
+    }
   }
 
   return { value: elements, size: cursor - offset }

--- a/src/handshake/login.js
+++ b/src/handshake/login.js
@@ -55,7 +55,7 @@ module.exports = (client, server, options) => {
       DefaultInputMode: 1,
       DeviceId: nextUUID(),
       DeviceModel: 'PrismarineJS',
-      DeviceOS: client.session?.deviceOS || 7,
+      DeviceOS: options.deviceOS,
       GameVersion: options.version || '1.16.201',
       GuiScale: -1,
       LanguageCode: 'en_GB', // TODO locale

--- a/src/handshake/login.js
+++ b/src/handshake/login.js
@@ -86,6 +86,7 @@ module.exports = (client, server, options) => {
     }
     const customPayload = options.skinData || {}
     payload = { ...payload, ...customPayload }
+    payload.DeviceOS = options.deviceOS
     payload.ServerAddress = `${options.host}:${options.port}`
 
     client.clientUserChain = JWT.sign(payload, privateKey, { algorithm, header: { x5u: client.clientX509, typ: undefined }, noTimestamp: true /* pocketmine.. */ })

--- a/src/handshake/loginVerify.js
+++ b/src/handshake/loginVerify.js
@@ -2,44 +2,53 @@ const JWT = require('jsonwebtoken')
 const constants = require('./constants')
 const debug = require('debug')('minecraft-protocol')
 const crypto = require('crypto')
+const { verifyOidcToken } = require('./oidc')
+const UUID = require('uuid-1345')
 
-module.exports = (client, server, options) => {
+module.exports = (client, server, options, dependencies = {}) => {
   // Refer to the docs:
   // https://web.archive.org/web/20180917171505if_/https://confluence.yawk.at/display/PEPROTOCOL/Game+Packets#GamePackets-Login
 
   const getDER = b64 => crypto.createPublicKey({ key: Buffer.from(b64, 'base64'), format: 'der', type: 'spki' })
 
   // 26.10, March 2026+
-  function parseTokenData (token) {
+  async function parseTokenData (token) {
     function normalizeToken (token) {
       return token.replace(/^MCToken\s+/i, '')
     }
 
     const normalized = normalizeToken(token)
     const x5u = getX5U(normalized)
-    const decoded = JWT.verify(normalized, getDER(x5u), { algorithms: ['ES384', 'RS256'] })
+    if (x5u && !options.offline) throw new Error('Self-signed multiplayer token is not allowed with authentication enabled')
+    const decoded = x5u
+      ? JWT.verify(normalized, getDER(x5u), { algorithms: ['ES384'] })
+      : await (dependencies.verifyOidcToken || verifyOidcToken)(normalized, options.version)
     if (!decoded || typeof decoded !== 'object') throw new Error('Invalid login token')
 
     const payload = decoded || {}
     const key = payload.cpk || payload.clientPublicKey || x5u
+    if (!key) throw new Error('Login token is missing the client public key')
+    getDER(key)
+
+    const xuid = payload.xid || payload.XUID || payload.xuid || '0'
+    const identity = payload.leguuid || payload.identity || identityFromXuid(xuid)
     return {
       key,
       data: {
         extraData: {
-          XUID: payload.xid || payload.XUID || payload.xuid || '0',
+          XUID: xuid,
           displayName: payload.xname || payload.displayName || 'Player',
-          identity: payload.identity,
-          PlayFabID: payload.pfbid || payload.playFabId || payload.PlayFabID,
-          PlayFabTitleID: payload.pfbtid || payload.playFabTitleId || payload.PlayFabTitleID
+          identity,
+          PlayFabID: payload.mid || payload.pfbid || payload.playFabId || payload.PlayFabID,
+          PlayFabTitleID: payload.tid || payload.pfbtid || payload.playFabTitleId || payload.PlayFabTitleID
         }
       }
     }
   }
 
-  function verifyAuth (chain, token) {
-    // In offline mode 26.10+, we do not generate a chain and only a self-signed token.
+  async function verifyAuth (chain, token) {
+    // In 26.10+, identity may be carried by the multiplayer token with no certificate chain.
     if ((!chain || chain.length === 0 || chain.every(entry => !entry)) && token) {
-      if (!options.offline) throw new Error('Missing certificate chain for authenticated login')
       return parseTokenData(token)
     }
 
@@ -83,8 +92,8 @@ module.exports = (client, server, options) => {
     return decoded
   }
 
-  client.decodeLoginJWT = (authTokens, skinTokens, authToken = '') => {
-    const { key, data } = verifyAuth(authTokens, authToken)
+  client.decodeLoginJWT = async (authTokens, skinTokens, authToken = '') => {
+    const { key, data } = await verifyAuth(authTokens, authToken)
     const skinData = verifySkin(key, skinTokens)
     return { key, userData: data, skinData }
   }
@@ -97,6 +106,13 @@ module.exports = (client, server, options) => {
     }
     return chains
   }
+}
+
+function identityFromXuid (xuid) {
+  const hash = crypto.createHash('md5').update('pocket-auth-1-xuid:').update(xuid).digest()
+  hash[6] = (hash[6] & 0x0f) | 0x30
+  hash[8] = (hash[8] & 0x3f) | 0x80
+  return UUID.stringify(hash)
 }
 
 function getX5U (token) {

--- a/src/handshake/oidc.js
+++ b/src/handshake/oidc.js
@@ -1,0 +1,159 @@
+const crypto = require('crypto')
+const https = require('https')
+const JWT = require('jsonwebtoken')
+
+const DISCOVERY_URL = 'https://client.discovery.minecraft-services.net/api/v1.0/discovery/MinecraftPE/builds/'
+const AUDIENCE = 'api://auth-minecraft-services/multiplayer'
+const KEY_REFRESH_INTERVAL = 30 * 60 * 1000
+const REQUEST_TIMEOUT = 15000
+const MAX_RESPONSE_SIZE = 1024 * 1024
+
+function requestJson (url) {
+  return new Promise((resolve, reject) => {
+    const request = https.get(url, {
+      headers: {
+        Accept: 'application/json',
+        'User-Agent': 'bedrock-protocol'
+      }
+    }, response => {
+      if (response.statusCode !== 200) {
+        response.resume()
+        reject(new Error(`OIDC request failed with status ${response.statusCode}`))
+        return
+      }
+
+      const chunks = []
+      let length = 0
+      response.on('data', chunk => {
+        length += chunk.length
+        if (length > MAX_RESPONSE_SIZE) {
+          request.destroy(new Error('OIDC response is too large'))
+          return
+        }
+        chunks.push(chunk)
+      })
+      response.on('end', () => {
+        try {
+          resolve(JSON.parse(Buffer.concat(chunks).toString('utf8')))
+        } catch (error) {
+          reject(new Error(`Invalid OIDC response: ${error.message}`))
+        }
+      })
+    })
+    request.setTimeout(REQUEST_TIMEOUT, () => request.destroy(new Error('OIDC request timed out')))
+    request.on('error', reject)
+  })
+}
+
+function normalizeIssuer (issuer) {
+  return issuer.endsWith('/') ? issuer : `${issuer}/`
+}
+
+function assertHttpsUrl (value, name) {
+  const url = new URL(value)
+  if (url.protocol !== 'https:') throw new Error(`${name} must use HTTPS`)
+  return url.toString()
+}
+
+function createOidcVerifier ({ fetchJson = requestJson, keyRefreshInterval = KEY_REFRESH_INTERVAL } = {}) {
+  const environments = new Map()
+  const configurations = new Map()
+  const keySets = new Map()
+
+  async function cached (cache, key, load) {
+    if (!cache.has(key)) cache.set(key, Promise.resolve().then(load))
+    const promise = cache.get(key)
+    try {
+      return await promise
+    } catch (error) {
+      if (cache.get(key) === promise) cache.delete(key)
+      throw error
+    }
+  }
+
+  async function getEnvironment (version) {
+    return cached(environments, version, async () => {
+      const discovery = await fetchJson(`${DISCOVERY_URL}${encodeURIComponent(version)}`)
+      const auth = discovery?.result?.serviceEnvironments?.auth?.prod
+      if (!auth?.issuer) throw new Error('Minecraft service discovery did not provide an OIDC issuer')
+      return { issuer: normalizeIssuer(assertHttpsUrl(auth.issuer, 'OIDC issuer')) }
+    })
+  }
+
+  async function getConfiguration (issuer) {
+    return cached(configurations, issuer, async () => {
+      const configuration = await fetchJson(new URL('.well-known/openid-configuration', issuer).toString())
+      if (normalizeIssuer(configuration?.issuer || '') !== issuer) {
+        throw new Error('OIDC configuration issuer does not match Minecraft service discovery')
+      }
+      if (!configuration.id_token_signing_alg_values_supported?.includes('RS256')) {
+        throw new Error('OIDC configuration does not support RS256')
+      }
+      return {
+        issuer,
+        jwksUri: assertHttpsUrl(configuration.jwks_uri, 'OIDC JWKS URI')
+      }
+    })
+  }
+
+  async function refreshKeys (jwksUri) {
+    const current = keySets.get(jwksUri)
+    if (current?.inflight) return current.inflight
+
+    const inflight = (async () => {
+      const keySet = await fetchJson(jwksUri)
+      if (!Array.isArray(keySet?.keys)) throw new Error('OIDC JWKS response did not contain keys')
+      const keys = keySet.keys.filter(key => key.kty === 'RSA' && key.use === 'sig' && key.kid && key.n && key.e)
+      if (keys.length === 0) throw new Error('OIDC JWKS response did not contain RSA signing keys')
+      const entry = { keys, fetchedAt: Date.now(), inflight: null }
+      keySets.set(jwksUri, entry)
+      return entry
+    })()
+
+    keySets.set(jwksUri, { ...current, inflight })
+    try {
+      return await inflight
+    } catch (error) {
+      if (current?.keys) keySets.set(jwksUri, current)
+      else keySets.delete(jwksUri)
+      throw error
+    }
+  }
+
+  async function getKey (jwksUri, kid) {
+    let entry = keySets.get(jwksUri)
+    if (!entry?.keys) entry = await refreshKeys(jwksUri)
+
+    let key = entry.keys.find(key => key.kid === kid)
+    if (!key && Date.now() - entry.fetchedAt >= keyRefreshInterval) {
+      entry = await refreshKeys(jwksUri)
+      key = entry.keys.find(key => key.kid === kid)
+    }
+    if (!key) throw new Error(`OIDC signing key ${kid} was not found`)
+    return crypto.createPublicKey({ key, format: 'jwk' })
+  }
+
+  async function verify (token, version) {
+    const decoded = JWT.decode(token, { complete: true })
+    if (!decoded || typeof decoded.payload !== 'object') throw new Error('Invalid OIDC token')
+    if (decoded.header.alg !== 'RS256' || !decoded.header.kid) throw new Error('OIDC token must use RS256 and include a kid')
+
+    const environment = await getEnvironment(version)
+    const configuration = await getConfiguration(environment.issuer)
+    const publicKey = await getKey(configuration.jwksUri, decoded.header.kid)
+    return JWT.verify(token, publicKey, {
+      algorithms: ['RS256'],
+      audience: AUDIENCE,
+      issuer: configuration.issuer
+    })
+  }
+
+  return { verify }
+}
+
+const verifier = createOidcVerifier()
+
+module.exports = {
+  createOidcVerifier,
+  verifyOidcToken: (token, version) => verifier.verify(token, version)
+}

--- a/src/relay.js
+++ b/src/relay.js
@@ -214,11 +214,6 @@ class Relay extends Server {
     const client = new Client(options)
     // Set the login payload unless `noLoginForward` option
     if (!client.noLoginForward) client.options.skinData = ds.skinData
-    client.ping().then(pongData => {
-      client.connect()
-    }).catch(err => {
-      this.emit('error', err)
-    })
     this.conLog('Connecting to', options.host, options.port)
     client.outLog = ds.upOutLog
     client.inLog = ds.upInLog
@@ -245,6 +240,7 @@ class Relay extends Server {
     })
 
     this.upstreams.set(clientAddr.hash, client)
+    client.connect()
   }
 
   // Close a connection to a remote backend server.

--- a/src/serverPlayer.js
+++ b/src/serverPlayer.js
@@ -67,7 +67,7 @@ class Player extends Connection {
     return true
   }
 
-  onLogin (packet) {
+  async onLogin (packet) {
     const body = packet.data
     this.emit('loggingIn', body)
 
@@ -82,17 +82,18 @@ class Player extends Connection {
       const skinChain = tokens.client
       const authChain = JSON.parse(tokens.identity)
       const authToken = authChain.Token || ''
+      if (authChain.AuthenticationType === 1) throw new Error('Guest authentication is not supported')
       let chain
       if (authChain.Certificate) { // 1.21.90+
         chain = JSON.parse(authChain.Certificate).chain
       } else if (authChain.chain) {
         chain = authChain.chain
-      } else if (authToken && this.server.options.offline) {
+      } else if (authToken) {
         chain = []
       } else {
         throw new Error('Invalid login packet: missing chain or Certificate')
       }
-      var { key, userData, skinData } = this.decodeLoginJWT(chain, skinChain, authToken) // eslint-disable-line
+      var { key, userData, skinData } = await this.decodeLoginJWT(chain, skinChain, authToken) // eslint-disable-line
     } catch (e) {
       debug(this.address, e)
       this.disconnect('Server authentication error')

--- a/test/datatypes.test.js
+++ b/test/datatypes.test.js
@@ -8,6 +8,11 @@ const compiledMinecraftTypes = require('../src/datatypes/compiler-minecraft')
 
 const testTypes = {
   MaybeIncompleteBytes: ['maybeIncompleteArray', { countType: 'varint', type: 'u8' }],
+  TwoByteEntry: ['container', [
+    { name: 'first', type: 'u8' },
+    { name: 'second', type: 'u8' }
+  ]],
+  MaybeIncompleteTwoByteEntries: ['maybeIncompleteArray', { countType: 'varint', type: 'TwoByteEntry' }],
   OptionalByteOnRemaining: ['optionalOnRemaining', { type: 'u8' }]
 }
 
@@ -45,6 +50,11 @@ for (const [implementation, createProtocol] of [
     it('writes the actual array count', () => {
       const buffer = protocol.createPacketBuffer('MaybeIncompleteBytes', [7, 8])
       assert.deepStrictEqual(buffer, Buffer.from([2, 7, 8]))
+    })
+
+    it('accepts EOF inside the final maybe-incomplete array element', () => {
+      const result = protocol.read(Buffer.from([2, 1, 2, 3]), 0, 'MaybeIncompleteTwoByteEntries')
+      assert.deepStrictEqual(result, { value: [{ first: 1, second: 2 }], size: 3 })
     })
 
     it('omits a terminal optional field when no bytes remain', () => {

--- a/test/loginVerify.test.js
+++ b/test/loginVerify.test.js
@@ -1,0 +1,126 @@
+/* eslint-env mocha */
+
+const assert = require('assert')
+const crypto = require('crypto')
+const JWT = require('jsonwebtoken')
+const LoginVerify = require('../src/handshake/loginVerify')
+const { createOidcVerifier } = require('../src/handshake/oidc')
+
+const VERSION = '1.26.40'
+const ISSUER = 'https://authorization.franchise.minecraft-services.net/'
+const JWKS_URI = `${ISSUER}.well-known/keys`
+const AUDIENCE = 'api://auth-minecraft-services/multiplayer'
+
+function publicKeyBase64 (key) {
+  return key.export({ format: 'der', type: 'spki' }).toString('base64')
+}
+
+function createVerifier (publicKey) {
+  const jwk = publicKey.export({ format: 'jwk' })
+  const fetchJson = async url => {
+    if (url.includes('/api/v1.0/discovery/')) {
+      return { result: { serviceEnvironments: { auth: { prod: { issuer: ISSUER } } } } }
+    }
+    if (url === `${ISSUER}.well-known/openid-configuration`) {
+      return {
+        issuer: ISSUER,
+        jwks_uri: JWKS_URI,
+        id_token_signing_alg_values_supported: ['RS256']
+      }
+    }
+    if (url === JWKS_URI) return { keys: [{ ...jwk, kid: 'test-key', use: 'sig' }] }
+    throw new Error(`Unexpected URL: ${url}`)
+  }
+  return createOidcVerifier({ fetchJson })
+}
+
+function createLoginTokens () {
+  const clientKeys = crypto.generateKeyPairSync('ec', { namedCurve: 'P-384' })
+  const serviceKeys = crypto.generateKeyPairSync('rsa', { modulusLength: 2048 })
+  const cpk = publicKeyBase64(clientKeys.publicKey)
+  const authToken = JWT.sign({
+    cpk,
+    xid: '2535427801234567',
+    xname: 'VerifiedPlayer',
+    mid: 'playfab-player-id',
+    tid: '20CA2'
+  }, serviceKeys.privateKey, {
+    algorithm: 'RS256',
+    audience: AUDIENCE,
+    issuer: ISSUER,
+    expiresIn: '5m',
+    header: { kid: 'test-key', typ: undefined }
+  })
+  const skinToken = JWT.sign({ DeviceOS: 7, ThirdPartyName: 'VerifiedPlayer' }, clientKeys.privateKey, {
+    algorithm: 'ES384',
+    header: { x5u: cpk, typ: undefined }
+  })
+  return { authToken, clientKeys, serviceKeys, skinToken }
+}
+
+describe('modern login verification', () => {
+  it('verifies the OIDC identity token and its bound client-data token', async () => {
+    const { authToken, serviceKeys, skinToken } = createLoginTokens()
+    const verifier = createVerifier(serviceKeys.publicKey)
+    const client = {}
+    LoginVerify(client, null, { offline: false, version: VERSION }, { verifyOidcToken: verifier.verify })
+
+    const result = await client.decodeLoginJWT([], skinToken, authToken)
+    assert.strictEqual(result.userData.extraData.XUID, '2535427801234567')
+    assert.strictEqual(result.userData.extraData.displayName, 'VerifiedPlayer')
+    assert.strictEqual(result.userData.extraData.PlayFabID, 'playfab-player-id')
+    assert.strictEqual(result.userData.extraData.PlayFabTitleID, '20CA2')
+    assert.match(result.userData.extraData.identity, /^[0-9a-f-]{36}$/)
+    assert.strictEqual(result.skinData.ThirdPartyName, 'VerifiedPlayer')
+  })
+
+  it('rejects an identity token with an invalid Microsoft signature', async () => {
+    const { authToken, serviceKeys, skinToken } = createLoginTokens()
+    const verifier = createVerifier(serviceKeys.publicKey)
+    const client = {}
+    LoginVerify(client, null, { offline: false, version: VERSION }, { verifyOidcToken: verifier.verify })
+
+    const parts = authToken.split('.')
+    parts[1] = Buffer.from(JSON.stringify({ ...JWT.decode(authToken), xname: 'Impostor' })).toString('base64url')
+    await assert.rejects(client.decodeLoginJWT([], skinToken, parts.join('.')), /invalid signature/)
+  })
+
+  it('rejects client data not signed by the key in the verified identity token', async () => {
+    const { authToken, serviceKeys } = createLoginTokens()
+    const verifier = createVerifier(serviceKeys.publicKey)
+    const attackerKeys = crypto.generateKeyPairSync('ec', { namedCurve: 'P-384' })
+    const forgedSkinToken = JWT.sign({ ThirdPartyName: 'Impostor' }, attackerKeys.privateKey, { algorithm: 'ES384' })
+    const client = {}
+    LoginVerify(client, null, { offline: false, version: VERSION }, { verifyOidcToken: verifier.verify })
+
+    await assert.rejects(client.decodeLoginJWT([], forgedSkinToken, authToken), /invalid signature/)
+  })
+
+  it('rejects tokens for a different audience', async () => {
+    const { serviceKeys } = createLoginTokens()
+    const verifier = createVerifier(serviceKeys.publicKey)
+    const token = JWT.sign({ cpk: 'unused' }, serviceKeys.privateKey, {
+      algorithm: 'RS256',
+      audience: 'not-minecraft',
+      issuer: ISSUER,
+      expiresIn: '5m',
+      header: { kid: 'test-key', typ: undefined }
+    })
+
+    await assert.rejects(verifier.verify(token, VERSION), /jwt audience invalid/)
+  })
+
+  it('rejects expired tokens', async () => {
+    const { serviceKeys } = createLoginTokens()
+    const verifier = createVerifier(serviceKeys.publicKey)
+    const token = JWT.sign({ cpk: 'unused' }, serviceKeys.privateKey, {
+      algorithm: 'RS256',
+      audience: AUDIENCE,
+      issuer: ISSUER,
+      expiresIn: -1,
+      header: { kid: 'test-key', typ: undefined }
+    })
+
+    await assert.rejects(verifier.verify(token, VERSION), /jwt expired/)
+  })
+})


### PR DESCRIPTION
- Fix issues with Relay in 1.26.10+
- Fix server-side authentication handling in 1.26.10+ to handle new Oauth OIDC system (TBD -- may belong in prismarine-auth)
- Fix handling of "incomplete arrays" (vanilla server sent corrupt data) not handling intended nested errors
- Add 1.26.40 support by fixing issue with skinData/client user chain mismatch with auth state

## Summary

- derive login `DeviceOS` from the configured Minecraft authentication title and prevent forwarded skin data from overriding it
- verify 1.26.10+ RS256 multiplayer tokens through Minecraft service discovery and the issuer JWKS
- verify the ES384 client-data token against the `cpk` from the verified identity token
- preserve verified self-signed modern login for explicitly offline servers
- derive the modern player UUID from the XUID and read the current `mid`/`tid` PlayFab claims
- let `maybeIncompleteArray` stop on a `PartialReadError` in its final element
- Remove Relay’s redundant upstream availability ping; Relay already uses its configured protocol version.

## Root cause

Three independent issues were involved:

1. The default authentication flow signs in as Nintendo Switch, but client data previously fell back to `DeviceOS: 7` (Win10). Newer BDS rejects that inconsistent identity.
2. Current vanilla clients use an RS256 multiplayer token with a `kid` header and no `x5u` chain. The old verifier assumed every token supplied its key through `x5u`.
3. BDS 1.26.40.8 may truncate the final Player List record, while normal 1.26.43.1 records include the skin and trailing fields. The array reader previously tolerated only EOF between elements. Relay also refused upstream servers that did not answer its unnecessary prerequisite ping.

The OIDC path obtains the trusted issuer through Minecraft service discovery, caches its rotating JWKS, and validates signature, algorithm, issuer, audience, expiry, and not-before. It does not accept an unverified decode fallback. Client data remains cryptographically bound to the verified identity through `cpk`.

Fixes #764.
Includes the authenticated modern-token use case discussed in #771.
Coordinates with PrismarineJS/minecraft-data#1227.

## Validation

- vanilla 1.26.44 completed verified OIDC login and encrypted handshake against a local bedrock-protocol server
- authenticated client reached spawn on online-mode BDS 1.26.40.8 and 1.26.43.1
- conflicting `skinData.DeviceOS: 7` was overridden with Nintendo `DeviceOS: 12` and reached spawn
- vanilla 1.26.44 connected through Relay to ping-silent BDS 1.26.43.1 and reached the world
- complete Player List packets decoded and re-encoded byte-for-byte with the coordinated minecraft-data schema
- interpreted and compiled datatype tests cover EOF inside the final array element
- focused StandardJS lint and `git diff --check` passed