### PR TITLE
Fix authorization and login flow issues with server join process

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -112,7 +112,7 @@ A ServerPlayer instance also emits the following special events:
 * 'spawn' - emitted after the client lets the server know that it has successfully spawned
 * 'packet' - Emitted for all packets received by client
 
-`ServerPlayer#getAuthentication()` returns the same authentication result. Offline identities are explicitly marked `authenticated: false`, and their self-asserted XUID is normalized to `0`.
+Offline identities are explicitly marked `authenticated: false`, and their self-asserted XUID is normalized to `0`.
 
 ## Client usage
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -108,9 +108,11 @@ Server event emissions:
 A ServerPlayer instance also emits the following special events:
 * 'join' - the client is ready to recieve game packets after successful server-client handshake/encryption
 * 'close' - emitted when client quit the server
-* 'login' - emitted by client after the client has been authenticated by the server
+* 'login' - emitted after identity and client-data verification. The event value is `{ user, authentication }`, where `authentication` contains `authenticated`, `method` (`oidc`, `legacy`, or `offline`), and the verified issuer. Check `authenticated` rather than inferring trust from an XUID.
 * 'spawn' - emitted after the client lets the server know that it has successfully spawned
 * 'packet' - Emitted for all packets received by client
+
+`ServerPlayer#getAuthentication()` returns the same authentication result. Offline identities are explicitly marked `authenticated: false`, and their self-asserted XUID is normalized to `0`.
 
 ## Client usage
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -130,8 +130,10 @@ declare module 'bedrock-protocol' {
       name: string
     }
     version: string
+    authentication?: AuthenticationResult
 
     getUserData(): object
+    getAuthentication(): AuthenticationResult | undefined
 
     /**
      * Disconnects a client before it has logged in via a PlayStatus packet.
@@ -151,11 +153,17 @@ declare module 'bedrock-protocol' {
      */
     close(): void
 
-    on(event: 'login', cb: () => void): any
+    on(event: 'login', cb: (result: { user: object, authentication: AuthenticationResult }) => void): any
     on(event: 'join', cb: () => void): any
     on(event: 'close', cb: (reason: string) => void): any
     on(event: 'packet', cb: (packet: object) => void): any
     on(event: 'spawn', cb: (reason: string) => void): any
+  }
+
+  export interface AuthenticationResult {
+    authenticated: boolean
+    method: 'oidc' | 'legacy' | 'offline'
+    issuer: string | null
   }
 
   export class Server extends EventEmitter {

--- a/index.d.ts
+++ b/index.d.ts
@@ -133,7 +133,6 @@ declare module 'bedrock-protocol' {
     authentication?: AuthenticationResult
 
     getUserData(): object
-    getAuthentication(): AuthenticationResult | undefined
 
     /**
      * Disconnects a client before it has logged in via a PlayStatus packet.

--- a/src/auth/loginEnvelope.js
+++ b/src/auth/loginEnvelope.js
@@ -37,7 +37,6 @@ function parseLoginEnvelope (packet) {
   if (!Array.isArray(chain)) throw new AuthenticationError('Login certificate chain must be an array')
   return {
     protocolVersion: params.protocol_version,
-    authenticationType: identityEnvelope.AuthenticationType,
     chain,
     multiplayerToken,
     clientDataToken: tokens.client

--- a/src/auth/loginEnvelope.js
+++ b/src/auth/loginEnvelope.js
@@ -1,0 +1,47 @@
+const { AuthenticationError } = require('./loginVerifier')
+
+function parseJson (value, label) {
+  if (typeof value !== 'string') throw new AuthenticationError(`${label} must be a JSON string`)
+  try {
+    return JSON.parse(value)
+  } catch (error) {
+    throw new AuthenticationError(`${label} is invalid JSON: ${error.message}`)
+  }
+}
+
+function parseLoginEnvelope (packet) {
+  const params = packet?.data?.params
+  const tokens = params?.tokens
+  if (!tokens || typeof tokens !== 'object') throw new AuthenticationError('Login packet is missing tokens')
+  if (typeof tokens.client !== 'string' || tokens.client.length === 0) {
+    throw new AuthenticationError('Login packet is missing its client-data token')
+  }
+
+  const identityEnvelope = parseJson(tokens.identity, 'Login identity envelope')
+  if (identityEnvelope.AuthenticationType === 1) {
+    throw new AuthenticationError('Guest authentication is not supported')
+  }
+
+  const multiplayerToken = identityEnvelope.Token || ''
+  let chain
+  if (identityEnvelope.Certificate) {
+    chain = parseJson(identityEnvelope.Certificate, 'Login Certificate').chain
+  } else if (identityEnvelope.chain) {
+    chain = identityEnvelope.chain
+  } else if (multiplayerToken) {
+    chain = []
+  } else {
+    throw new AuthenticationError('Login packet is missing its chain or Certificate')
+  }
+
+  if (!Array.isArray(chain)) throw new AuthenticationError('Login certificate chain must be an array')
+  return {
+    protocolVersion: params.protocol_version,
+    authenticationType: identityEnvelope.AuthenticationType,
+    chain,
+    multiplayerToken,
+    clientDataToken: tokens.client
+  }
+}
+
+module.exports = { parseLoginEnvelope }

--- a/src/auth/loginState.js
+++ b/src/auth/loginState.js
@@ -1,0 +1,57 @@
+const LoginPhase = Object.freeze({
+  AwaitingLogin: 'awaiting_login',
+  VerifyingLogin: 'verifying_login',
+  AwaitingClientHandshake: 'awaiting_client_handshake',
+  Complete: 'complete',
+  Rejected: 'rejected',
+  Closed: 'closed'
+})
+
+const transitions = {
+  [LoginPhase.AwaitingLogin]: new Set([LoginPhase.VerifyingLogin, LoginPhase.Rejected, LoginPhase.Closed]),
+  [LoginPhase.VerifyingLogin]: new Set([LoginPhase.AwaitingClientHandshake, LoginPhase.Rejected, LoginPhase.Closed]),
+  [LoginPhase.AwaitingClientHandshake]: new Set([LoginPhase.Complete, LoginPhase.Rejected, LoginPhase.Closed]),
+  [LoginPhase.Complete]: new Set([LoginPhase.Rejected, LoginPhase.Closed]),
+  [LoginPhase.Rejected]: new Set([LoginPhase.Closed]),
+  [LoginPhase.Closed]: new Set()
+}
+
+class ProtocolStateError extends Error {
+  constructor (current, expected) {
+    super(`Login packet is not allowed during ${current}; expected ${expected}`)
+    this.name = 'ProtocolStateError'
+  }
+}
+
+class LoginState {
+  #phase = LoginPhase.AwaitingLogin
+
+  get phase () {
+    return this.#phase
+  }
+
+  is (phase) {
+    return this.#phase === phase
+  }
+
+  require (phase) {
+    if (!this.is(phase)) throw new ProtocolStateError(this.#phase, phase)
+  }
+
+  transition (next) {
+    if (!transitions[this.#phase].has(next)) throw new ProtocolStateError(this.#phase, next)
+    this.#phase = next
+  }
+
+  reject () {
+    if (this.is(LoginPhase.Rejected) || this.is(LoginPhase.Closed)) return false
+    this.transition(LoginPhase.Rejected)
+    return true
+  }
+
+  close () {
+    if (!this.is(LoginPhase.Closed)) this.transition(LoginPhase.Closed)
+  }
+}
+
+module.exports = { LoginPhase, LoginState, ProtocolStateError }

--- a/src/auth/loginVerifier.js
+++ b/src/auth/loginVerifier.js
@@ -1,0 +1,193 @@
+const crypto = require('crypto')
+const JWT = require('jsonwebtoken')
+const UUID = require('uuid-1345')
+const constants = require('../handshake/constants')
+const { verifyOidcToken } = require('../handshake/oidc')
+
+const publicKeyExport = { format: 'der', type: 'spki' }
+
+class AuthenticationError extends Error {
+  constructor (message) {
+    super(message)
+    this.name = 'AuthenticationError'
+  }
+}
+
+function parsePublicKey (encoded, label = 'public key') {
+  if (typeof encoded !== 'string' || encoded.length === 0) {
+    throw new AuthenticationError(`Login ${label} is missing`)
+  }
+
+  let key
+  try {
+    key = crypto.createPublicKey({ key: Buffer.from(encoded, 'base64'), ...publicKeyExport })
+  } catch (error) {
+    throw new AuthenticationError(`Login ${label} is invalid: ${error.message}`)
+  }
+
+  if (key.asymmetricKeyType !== 'ec' || key.asymmetricKeyDetails?.namedCurve !== 'secp384r1') {
+    throw new AuthenticationError(`Login ${label} must be an EC P-384 key`)
+  }
+  return key
+}
+
+function encodePublicKey (key) {
+  return key.export(publicKeyExport).toString('base64')
+}
+
+function samePublicKey (left, right) {
+  return left.export(publicKeyExport).equals(right.export(publicKeyExport))
+}
+
+function protectedHeader (token) {
+  const decoded = JWT.decode(token, { complete: true })
+  if (!decoded || !decoded.header || typeof decoded.payload !== 'object') {
+    throw new AuthenticationError('Invalid login JWT')
+  }
+  return decoded.header
+}
+
+function keyFromX5u (token) {
+  return parsePublicKey(protectedHeader(token).x5u, 'JWT x5u public key')
+}
+
+function identityFromXuid (xuid) {
+  const hash = crypto.createHash('md5').update('pocket-auth-1-xuid:').update(xuid).digest()
+  hash[6] = (hash[6] & 0x0f) | 0x30
+  hash[8] = (hash[8] & 0x3f) | 0x80
+  return UUID.stringify(hash)
+}
+
+function validateIdentity (identity, authenticated) {
+  if (!identity || typeof identity !== 'object') {
+    throw new AuthenticationError('Login identity is missing')
+  }
+  if (typeof identity.displayName !== 'string' || identity.displayName.length === 0 || identity.displayName.length > 64) {
+    throw new AuthenticationError('Login display name must contain between 1 and 64 characters')
+  }
+  if (typeof identity.identity !== 'string' || !UUID.check(identity.identity) || identity.identity === UUID.nil.ascii) {
+    throw new AuthenticationError('Login identity UUID is invalid')
+  }
+  if (authenticated && (typeof identity.XUID !== 'string' || !/^[1-9][0-9]{0,19}$/.test(identity.XUID))) {
+    throw new AuthenticationError('Authenticated login XUID is invalid')
+  }
+}
+
+function canonicalIdentity (value, authenticated) {
+  const identity = {
+    ...value,
+    XUID: authenticated ? value.XUID : '0'
+  }
+  validateIdentity(identity, authenticated)
+  return identity
+}
+
+function createLoginVerifier (options, dependencies = {}) {
+  const allowOffline = options.offline === true
+  const mojangKey = parsePublicKey(dependencies.mojangPublicKey || constants.PUBLIC_KEY, 'pinned Mojang public key')
+  const oidcVerifier = dependencies.verifyOidcToken || verifyOidcToken
+
+  function verifyLegacyChain (chain) {
+    if (!Array.isArray(chain) || (chain.length !== 1 && chain.length !== 3)) {
+      throw new AuthenticationError(`Unexpected login chain length ${chain?.length ?? 0}`)
+    }
+
+    const initialClientKey = keyFromX5u(chain[0])
+    const token0 = JWT.verify(chain[0], initialClientKey, { algorithms: ['ES384'] })
+    const nextKey = parsePublicKey(token0.identityPublicKey, 'chain token 0 identity public key')
+
+    if (chain.length === 1) {
+      if (!allowOffline) throw new AuthenticationError('Offline login is not allowed with authentication enabled')
+      const identity = canonicalIdentity(token0.extraData, false)
+      return {
+        authentication: { authenticated: false, method: 'offline', issuer: null },
+        identity,
+        clientPublicKey: nextKey,
+        clientPublicKeyBase64: encodePublicKey(nextKey)
+      }
+    }
+
+    if (!samePublicKey(nextKey, mojangKey)) {
+      throw new AuthenticationError('Legacy login chain is not anchored by Mojang')
+    }
+
+    const token1 = JWT.verify(chain[1], nextKey, { algorithms: ['ES384'], issuer: 'Mojang' })
+    const intermediateKey = parsePublicKey(token1.identityPublicKey, 'chain token 1 identity public key')
+    const token2 = JWT.verify(chain[2], intermediateKey, { algorithms: ['ES384'], issuer: 'Mojang' })
+    const finalClientKey = parsePublicKey(token2.identityPublicKey, 'chain token 2 identity public key')
+    const identity = canonicalIdentity(token2.extraData, true)
+
+    return {
+      authentication: { authenticated: true, method: 'legacy', issuer: 'Mojang' },
+      identity,
+      clientPublicKey: finalClientKey,
+      clientPublicKeyBase64: encodePublicKey(finalClientKey)
+    }
+  }
+
+  async function verifyMultiplayerToken (token) {
+    const normalized = token.replace(/^MCToken\s+/i, '')
+    const header = protectedHeader(normalized)
+    const selfSigned = Boolean(header.x5u)
+    if (selfSigned && !allowOffline) {
+      throw new AuthenticationError('Self-signed multiplayer token is not allowed with authentication enabled')
+    }
+
+    const decoded = selfSigned
+      ? JWT.verify(normalized, parsePublicKey(header.x5u, 'multiplayer token x5u public key'), { algorithms: ['ES384'] })
+      : await oidcVerifier(normalized, options.version)
+    if (!decoded || typeof decoded !== 'object') throw new AuthenticationError('Invalid multiplayer token')
+    if (!selfSigned && (!Number.isInteger(decoded.exp) || decoded.exp <= 0)) {
+      throw new AuthenticationError('OIDC multiplayer token is missing its expiry')
+    }
+
+    const authenticated = !selfSigned
+    const clientPublicKeyBase64 = decoded.cpk || decoded.clientPublicKey || header.x5u
+    const clientPublicKey = parsePublicKey(clientPublicKeyBase64, 'multiplayer token client public key')
+    const xuid = decoded.xid || decoded.XUID || decoded.xuid || '0'
+    const identity = canonicalIdentity({
+      XUID: String(xuid),
+      displayName: decoded.xname || decoded.displayName,
+      identity: decoded.leguuid || decoded.identity || identityFromXuid(String(xuid)),
+      PlayFabID: decoded.mid || decoded.pfbid || decoded.playFabId || decoded.PlayFabID,
+      PlayFabTitleID: decoded.tid || decoded.pfbtid || decoded.playFabTitleId || decoded.PlayFabTitleID
+    }, authenticated)
+
+    return {
+      authentication: {
+        authenticated,
+        method: authenticated ? 'oidc' : 'offline',
+        issuer: authenticated ? decoded.iss : null
+      },
+      identity,
+      clientPublicKey,
+      clientPublicKeyBase64: encodePublicKey(clientPublicKey)
+    }
+  }
+
+  function verifyClientData (token, publicKey) {
+    const decoded = JWT.verify(token, publicKey, { algorithms: ['ES384'] })
+    if (!decoded || typeof decoded !== 'object') throw new AuthenticationError('Invalid client-data token')
+    return decoded
+  }
+
+  async function verifyLogin ({ chain, multiplayerToken = '', clientDataToken }) {
+    const verifiedIdentity = multiplayerToken
+      ? await verifyMultiplayerToken(multiplayerToken)
+      : verifyLegacyChain(chain)
+    return {
+      ...verifiedIdentity,
+      clientData: verifyClientData(clientDataToken, verifiedIdentity.clientPublicKey)
+    }
+  }
+
+  return { verifyLogin }
+}
+
+module.exports = {
+  AuthenticationError,
+  createLoginVerifier,
+  identityFromXuid,
+  parsePublicKey,
+  validateIdentity
+}

--- a/src/auth/loginVerifier.js
+++ b/src/auth/loginVerifier.js
@@ -140,6 +140,9 @@ function createLoginVerifier (options, dependencies = {}) {
     if (!selfSigned && (!Number.isInteger(decoded.exp) || decoded.exp <= 0)) {
       throw new AuthenticationError('OIDC multiplayer token is missing its expiry')
     }
+    if (!selfSigned && (typeof decoded.iss !== 'string' || decoded.iss.length === 0)) {
+      throw new AuthenticationError('OIDC multiplayer token is missing its issuer')
+    }
 
     const authenticated = !selfSigned
     const clientPublicKeyBase64 = decoded.cpk || decoded.clientPublicKey || header.x5u

--- a/src/client.js
+++ b/src/client.js
@@ -158,7 +158,7 @@ class Client extends Connection {
     } else {
       encodedChain = JSON.stringify({ chain })
     }
-    debug('Auth chain', encodedChain)
+    debug('Prepared login identity', { certificateTokens: chain.length, hasMultiplayerToken: Boolean(this.multiplayerToken) })
 
     this.write('login', {
       protocol_version: this.options.protocolVersion,

--- a/src/client.js
+++ b/src/client.js
@@ -5,7 +5,7 @@ const debug = require('debug')('minecraft-protocol')
 const Options = require('./options')
 const auth = require('./client/auth')
 const initRaknet = require('./rak')
-const { KeyExchange } = require('./handshake/keyExchange')
+const { createKeyExchange } = require('./handshake/keyExchange')
 const Login = require('./handshake/login')
 const LoginVerify = require('./handshake/loginVerify')
 
@@ -45,7 +45,11 @@ class Client extends Connection {
     this.deserializer = createDeserializer(this.options.version)
     this._loadFeatures()
 
-    KeyExchange(this, null, this.options)
+    this.keyExchange = createKeyExchange()
+    this.ecdhKeyPair = this.keyExchange.keyPair
+    this.publicKeyDER = this.keyExchange.publicKeyDER
+    this.privateKeyPEM = this.keyExchange.privateKeyPEM
+    this.clientX509 = this.keyExchange.clientX509
     Login(this, null, this.options)
     LoginVerify(this, null, this.options)
 
@@ -238,7 +242,17 @@ class Client extends Connection {
     // Abstract some boilerplate before sending to listeners
     switch (des.data.name) {
       case 'server_to_client_handshake':
-        this.emit('client.server_handshake', des.data.params)
+        try {
+          const encryption = this.keyExchange.verifyServerHandshake(des.data.params)
+          this.enableEncryption(encryption)
+          this.write('client_to_server_handshake', {})
+          this.status = ClientStatus.Initializing
+          this.emit('join')
+        } catch (error) {
+          this.emit('error', error)
+          this.close()
+          return
+        }
         break
       case 'network_settings':
         this.updateCompressorSettings(des.data.params)

--- a/src/client.js
+++ b/src/client.js
@@ -45,11 +45,7 @@ class Client extends Connection {
     this.deserializer = createDeserializer(this.options.version)
     this._loadFeatures()
 
-    this.keyExchange = createKeyExchange()
-    this.ecdhKeyPair = this.keyExchange.keyPair
-    this.publicKeyDER = this.keyExchange.publicKeyDER
-    this.privateKeyPEM = this.keyExchange.privateKeyPEM
-    this.clientX509 = this.keyExchange.clientX509
+    createKeyExchange(this)
     Login(this, null, this.options)
     LoginVerify(this, null, this.options)
 
@@ -243,7 +239,7 @@ class Client extends Connection {
     switch (des.data.name) {
       case 'server_to_client_handshake':
         try {
-          const encryption = this.keyExchange.verifyServerHandshake(des.data.params)
+          const encryption = this.verifyServerHandshake(des.data.params)
           this.enableEncryption(encryption)
           this.write('client_to_server_handshake', {})
           this.status = ClientStatus.Initializing

--- a/src/client.js
+++ b/src/client.js
@@ -5,7 +5,7 @@ const debug = require('debug')('minecraft-protocol')
 const Options = require('./options')
 const auth = require('./client/auth')
 const initRaknet = require('./rak')
-const { createKeyExchange } = require('./handshake/keyExchange')
+const KeyExchange = require('./handshake/keyExchange')
 const Login = require('./handshake/login')
 const LoginVerify = require('./handshake/loginVerify')
 
@@ -45,7 +45,7 @@ class Client extends Connection {
     this.deserializer = createDeserializer(this.options.version)
     this._loadFeatures()
 
-    createKeyExchange(this)
+    KeyExchange(this)
     Login(this, null, this.options)
     LoginVerify(this, null, this.options)
 

--- a/src/connection.js
+++ b/src/connection.js
@@ -49,7 +49,7 @@ class Connection extends EventEmitter {
 
   startEncryption (iv) {
     this.encryptionEnabled = true
-    this.inLog?.('Started encryption', this.sharedSecret, iv)
+    this.inLog?.('Started encryption')
     this.decrypt = cipher.createDecryptor(this, iv)
     this.encrypt = cipher.createEncryptor(this, iv)
   }

--- a/src/connection.js
+++ b/src/connection.js
@@ -54,6 +54,12 @@ class Connection extends EventEmitter {
     this.encrypt = cipher.createEncryptor(this, iv)
   }
 
+  enableEncryption (material) {
+    this.sharedSecret = material.sharedSecret
+    this.secretKeyBytes = material.secretKeyBytes
+    this.startEncryption(material.iv)
+  }
+
   updateItemPalette (palette) {
     // In the future, we can send down the whole item palette if we need
     // but since it's only one item, we can just make a single variable.

--- a/src/connection.js
+++ b/src/connection.js
@@ -23,8 +23,8 @@ class Connection extends EventEmitter {
 
   set status (val) {
     debug('* new status', val)
-    this.emit('status', val)
     this.#status = val
+    this.emit('status', val)
   }
 
   versionLessThan (version) {

--- a/src/handshake/keyExchange.js
+++ b/src/handshake/keyExchange.js
@@ -1,90 +1,83 @@
-const { ClientStatus } = require('../connection')
 const JWT = require('jsonwebtoken')
 const crypto = require('crypto')
-const debug = require('debug')('minecraft-protocol')
 
 const curve = 'secp384r1'
 const pem = { format: 'pem', type: 'sec1' }
 const der = { format: 'der', type: 'spki' }
 
-function KeyExchange (client, server, options) {
-  // Generate a key pair at program start up
-  client.ecdhKeyPair = crypto.generateKeyPairSync('ec', { namedCurve: curve })
-  client.publicKeyDER = client.ecdhKeyPair.publicKey.export(der)
-  client.privateKeyPEM = client.ecdhKeyPair.privateKey.export(pem)
-  client.clientX509 = client.publicKeyDER.toString('base64')
+function createKeyExchange () {
+  const keyPair = crypto.generateKeyPairSync('ec', { namedCurve: curve })
+  const publicKeyDER = keyPair.publicKey.export(der)
+  const privateKeyPEM = keyPair.privateKey.export(pem)
+  const clientX509 = publicKeyDER.toString('base64')
 
-  function startClientboundEncryption (publicKey) {
-    debug('[encrypt] Client pub key base64: ', publicKey)
+  function parseRemoteKey (value) {
+    const key = value instanceof crypto.KeyObject
+      ? value
+      : crypto.createPublicKey({ key: Buffer.from(value, 'base64'), ...der })
+    if (key.asymmetricKeyType !== 'ec' || key.asymmetricKeyDetails?.namedCurve !== curve) {
+      throw new Error('Handshake public key must be an EC P-384 key')
+    }
+    return key
+  }
 
-    const pubKeyDer = crypto.createPublicKey({ key: Buffer.from(publicKey.key, 'base64'), ...der })
-    // Shared secret from the client's public key + our private key
-    client.sharedSecret = crypto.diffieHellman({ privateKey: client.ecdhKeyPair.privateKey, publicKey: pubKeyDer })
+  function deriveEncryption (remotePublicKey, salt) {
+    const sharedSecret = crypto.diffieHellman({
+      privateKey: keyPair.privateKey,
+      publicKey: remotePublicKey
+    })
+    const secretKeyBytes = crypto.createHash('sha256')
+      .update(salt)
+      .update(sharedSecret)
+      .digest()
+    return {
+      sharedSecret,
+      secretKeyBytes,
+      iv: secretKeyBytes.subarray(0, 16)
+    }
+  }
 
-    // Secret hash we use for packet encryption:
-    // From the public key of the remote and the private key
-    // of the local, a shared secret is generated using ECDH.
-    // The secret key bytes are then computed as
-    // sha256(server_token + shared_secret). These secret key
-    //  bytes are 32 bytes long.
+  function createServerHandshake (clientPublicKey) {
+    const remotePublicKey = parseRemoteKey(clientPublicKey)
     const salt = crypto.randomBytes(16)
-    const secretHash = crypto.createHash('sha256')
-    secretHash.update(salt)
-    secretHash.update(client.sharedSecret)
-
-    client.secretKeyBytes = secretHash.digest()
-
+    const encryption = deriveEncryption(remotePublicKey, salt)
     const token = JWT.sign({
       salt: salt.toString('base64'),
-      signedToken: client.clientX509
-    }, client.ecdhKeyPair.privateKey, { algorithm: 'ES384', header: { x5u: client.clientX509 } })
-
-    client.write('server_to_client_handshake', { token })
-
-    // The encryption scheme is AES/CFB8/NoPadding with the
-    // secret key being the result of the sha256 above and
-    // the IV being the first 16 bytes of this secret key.
-    const initial = client.secretKeyBytes.slice(0, 16)
-    client.startEncryption(initial)
+      signedToken: clientX509
+    }, keyPair.privateKey, {
+      algorithm: 'ES384',
+      header: { x5u: clientX509 }
+    })
+    return { token, ...encryption }
   }
 
-  function startServerboundEncryption (token) {
-    debug('[encrypt] Starting serverbound encryption')
-    const jwt = token?.token
-    if (!jwt) {
-      throw Error('Server did not return a valid JWT, cannot start encryption')
-    }
+  function verifyServerHandshake (packet) {
+    const token = packet?.token
+    if (!token) throw new Error('Server did not return a valid JWT, cannot start encryption')
 
-    const decoded = JWT.decode(jwt, { complete: true })
+    const decoded = JWT.decode(token, { complete: true })
     const x5u = decoded?.header?.x5u
-    if (!x5u) throw Error('Server handshake JWT is missing its public key')
-    const pubKeyDer = crypto.createPublicKey({ key: Buffer.from(x5u, 'base64'), ...der })
+    if (!x5u) throw new Error('Server handshake JWT is missing its public key')
+    const remotePublicKey = parseRemoteKey(x5u)
     // The key is self-declared, so this does not authenticate the server's
     // identity. It does ensure that the key used for ECDH signed the payload.
-    const body = JWT.verify(jwt, pubKeyDer, { algorithms: ['ES384'] })
-    if (!body?.salt || typeof body.salt !== 'string') throw Error('Server handshake JWT is missing its salt')
-
-    // Shared secret from the client's public key + our private key
-    client.sharedSecret = crypto.diffieHellman({ privateKey: client.ecdhKeyPair.privateKey, publicKey: pubKeyDer })
-
-    const salt = Buffer.from(body.salt, 'base64')
-    const secretHash = crypto.createHash('sha256')
-    secretHash.update(salt)
-    secretHash.update(client.sharedSecret)
-
-    client.secretKeyBytes = secretHash.digest()
-    const iv = client.secretKeyBytes.slice(0, 16)
-    client.startEncryption(iv)
-
-    // It works! First encrypted packet :)
-
-    client.write('client_to_server_handshake', {})
-    client.emit('join')
-    client.status = ClientStatus.Initializing
+    const claims = JWT.verify(token, remotePublicKey, { algorithms: ['ES384'] })
+    if (!claims?.salt || typeof claims.salt !== 'string') {
+      throw new Error('Server handshake JWT is missing its salt')
+    }
+    const salt = Buffer.from(claims.salt, 'base64')
+    if (salt.length === 0 || salt.length > 64) throw new Error('Server handshake salt has an invalid length')
+    return deriveEncryption(remotePublicKey, salt)
   }
 
-  client.on('server.client_handshake', startClientboundEncryption)
-  client.on('client.server_handshake', startServerboundEncryption)
+  return {
+    keyPair,
+    publicKeyDER,
+    privateKeyPEM,
+    clientX509,
+    createServerHandshake,
+    verifyServerHandshake
+  }
 }
 
-module.exports = { KeyExchange }
+module.exports = { createKeyExchange }

--- a/src/handshake/keyExchange.js
+++ b/src/handshake/keyExchange.js
@@ -5,7 +5,7 @@ const curve = 'secp384r1'
 const pem = { format: 'pem', type: 'sec1' }
 const der = { format: 'der', type: 'spki' }
 
-function createKeyExchange (client) {
+function KeyExchange (client) {
   const keyPair = crypto.generateKeyPairSync('ec', { namedCurve: curve })
   const publicKeyDER = keyPair.publicKey.export(der)
   const privateKeyPEM = keyPair.privateKey.export(pem)
@@ -78,4 +78,4 @@ function createKeyExchange (client) {
   client.verifyServerHandshake = verifyServerHandshake
 }
 
-module.exports = { createKeyExchange }
+module.exports = KeyExchange

--- a/src/handshake/keyExchange.js
+++ b/src/handshake/keyExchange.js
@@ -3,7 +3,6 @@ const JWT = require('jsonwebtoken')
 const crypto = require('crypto')
 const debug = require('debug')('minecraft-protocol')
 
-const SALT = '🧂'
 const curve = 'secp384r1'
 const pem = { format: 'pem', type: 'sec1' }
 const der = { format: 'der', type: 'spki' }
@@ -28,14 +27,15 @@ function KeyExchange (client, server, options) {
     // The secret key bytes are then computed as
     // sha256(server_token + shared_secret). These secret key
     //  bytes are 32 bytes long.
+    const salt = crypto.randomBytes(16)
     const secretHash = crypto.createHash('sha256')
-    secretHash.update(SALT)
+    secretHash.update(salt)
     secretHash.update(client.sharedSecret)
 
     client.secretKeyBytes = secretHash.digest()
 
     const token = JWT.sign({
-      salt: toBase64(SALT),
+      salt: salt.toString('base64'),
       signedToken: client.clientX509
     }, client.ecdhKeyPair.privateKey, { algorithm: 'ES384', header: { x5u: client.clientX509 } })
 
@@ -49,19 +49,20 @@ function KeyExchange (client, server, options) {
   }
 
   function startServerboundEncryption (token) {
-    debug('[encrypt] Starting serverbound encryption', token)
+    debug('[encrypt] Starting serverbound encryption')
     const jwt = token?.token
     if (!jwt) {
       throw Error('Server did not return a valid JWT, cannot start encryption')
     }
 
-    // No verification here, not needed
-
-    const [header, payload] = jwt.split('.').map(k => Buffer.from(k, 'base64'))
-    const head = JSON.parse(String(header))
-    const body = JSON.parse(String(payload))
-
-    const pubKeyDer = crypto.createPublicKey({ key: Buffer.from(head.x5u, 'base64'), ...der })
+    const decoded = JWT.decode(jwt, { complete: true })
+    const x5u = decoded?.header?.x5u
+    if (!x5u) throw Error('Server handshake JWT is missing its public key')
+    const pubKeyDer = crypto.createPublicKey({ key: Buffer.from(x5u, 'base64'), ...der })
+    // The key is self-declared, so this does not authenticate the server's
+    // identity. It does ensure that the key used for ECDH signed the payload.
+    const body = JWT.verify(jwt, pubKeyDer, { algorithms: ['ES384'] })
+    if (!body?.salt || typeof body.salt !== 'string') throw Error('Server handshake JWT is missing its salt')
 
     // Shared secret from the client's public key + our private key
     client.sharedSecret = crypto.diffieHellman({ privateKey: client.ecdhKeyPair.privateKey, publicKey: pubKeyDer })
@@ -78,16 +79,12 @@ function KeyExchange (client, server, options) {
     // It works! First encrypted packet :)
 
     client.write('client_to_server_handshake', {})
-    this.emit('join')
+    client.emit('join')
     client.status = ClientStatus.Initializing
   }
 
   client.on('server.client_handshake', startClientboundEncryption)
   client.on('client.server_handshake', startServerboundEncryption)
-}
-
-function toBase64 (string) {
-  return Buffer.from(string).toString('base64')
 }
 
 module.exports = { KeyExchange }

--- a/src/handshake/keyExchange.js
+++ b/src/handshake/keyExchange.js
@@ -5,7 +5,7 @@ const curve = 'secp384r1'
 const pem = { format: 'pem', type: 'sec1' }
 const der = { format: 'der', type: 'spki' }
 
-function createKeyExchange () {
+function createKeyExchange (client) {
   const keyPair = crypto.generateKeyPairSync('ec', { namedCurve: curve })
   const publicKeyDER = keyPair.publicKey.export(der)
   const privateKeyPEM = keyPair.privateKey.export(pem)
@@ -70,14 +70,12 @@ function createKeyExchange () {
     return deriveEncryption(remotePublicKey, salt)
   }
 
-  return {
-    keyPair,
-    publicKeyDER,
-    privateKeyPEM,
-    clientX509,
-    createServerHandshake,
-    verifyServerHandshake
-  }
+  client.ecdhKeyPair = keyPair
+  client.publicKeyDER = publicKeyDER
+  client.privateKeyPEM = privateKeyPEM
+  client.clientX509 = clientX509
+  client.createServerHandshake = createServerHandshake
+  client.verifyServerHandshake = verifyServerHandshake
 }
 
 module.exports = { createKeyExchange }

--- a/src/handshake/loginVerify.js
+++ b/src/handshake/loginVerify.js
@@ -1,13 +1,13 @@
 const { createLoginVerifier } = require('../auth/loginVerifier')
 
-// Compatibility adapter for callers that use decodeLoginJWT directly. New
-// server code should call createLoginVerifier().verifyLogin() instead.
+// Install direct verification methods while preserving decodeLoginJWT for
+// callers using the older API shape.
 module.exports = (client, server, options, dependencies = {}) => {
-  const verifier = dependencies.loginVerifier || createLoginVerifier(options, dependencies)
-  client.loginVerifier = verifier
+  const verifier = createLoginVerifier(options, dependencies)
+  client.verifyLogin = verifier.verifyLogin
 
   client.decodeLoginJWT = async (authTokens, skinToken, authToken = '') => {
-    const result = await verifier.verifyLogin({
+    const result = await client.verifyLogin({
       chain: authTokens,
       multiplayerToken: authToken,
       clientDataToken: skinToken

--- a/src/handshake/loginVerify.js
+++ b/src/handshake/loginVerify.js
@@ -3,7 +3,8 @@ const { createLoginVerifier } = require('../auth/loginVerifier')
 // Compatibility adapter for callers that use decodeLoginJWT directly. New
 // server code should call createLoginVerifier().verifyLogin() instead.
 module.exports = (client, server, options, dependencies = {}) => {
-  const verifier = createLoginVerifier(options, dependencies)
+  const verifier = dependencies.loginVerifier || createLoginVerifier(options, dependencies)
+  client.loginVerifier = verifier
 
   client.decodeLoginJWT = async (authTokens, skinToken, authToken = '') => {
     const result = await verifier.verifyLogin({

--- a/src/handshake/loginVerify.js
+++ b/src/handshake/loginVerify.js
@@ -1,132 +1,23 @@
-const JWT = require('jsonwebtoken')
-const constants = require('./constants')
-const debug = require('debug')('minecraft-protocol')
-const crypto = require('crypto')
-const { verifyOidcToken } = require('./oidc')
-const UUID = require('uuid-1345')
+const { createLoginVerifier } = require('../auth/loginVerifier')
 
+// Compatibility adapter for callers that use decodeLoginJWT directly. New
+// server code should call createLoginVerifier().verifyLogin() instead.
 module.exports = (client, server, options, dependencies = {}) => {
-  // Refer to the docs:
-  // https://web.archive.org/web/20180917171505if_/https://confluence.yawk.at/display/PEPROTOCOL/Game+Packets#GamePackets-Login
+  const verifier = createLoginVerifier(options, dependencies)
 
-  const getDER = b64 => crypto.createPublicKey({ key: Buffer.from(b64, 'base64'), format: 'der', type: 'spki' })
-  const samePublicKey = (left, right) => left.export({ format: 'der', type: 'spki' }).equals(right.export({ format: 'der', type: 'spki' }))
-
-  // 26.10, March 2026+
-  async function parseTokenData (token) {
-    function normalizeToken (token) {
-      return token.replace(/^MCToken\s+/i, '')
-    }
-
-    const normalized = normalizeToken(token)
-    const x5u = getX5U(normalized)
-    if (x5u && !options.offline) throw new Error('Self-signed multiplayer token is not allowed with authentication enabled')
-    const decoded = x5u
-      ? JWT.verify(normalized, getDER(x5u), { algorithms: ['ES384'] })
-      : await (dependencies.verifyOidcToken || verifyOidcToken)(normalized, options.version)
-    if (!decoded || typeof decoded !== 'object') throw new Error('Invalid login token')
-
-    const payload = decoded || {}
-    const key = payload.cpk || payload.clientPublicKey || x5u
-    if (!key) throw new Error('Login token is missing the client public key')
-    getDER(key)
-
-    const xuid = payload.xid || payload.XUID || payload.xuid || '0'
-    const identity = payload.leguuid || payload.identity || identityFromXuid(xuid)
+  client.decodeLoginJWT = async (authTokens, skinToken, authToken = '') => {
+    const result = await verifier.verifyLogin({
+      chain: authTokens,
+      multiplayerToken: authToken,
+      clientDataToken: skinToken
+    })
     return {
-      key,
-      data: {
-        extraData: {
-          XUID: xuid,
-          displayName: payload.xname || payload.displayName || 'Player',
-          identity,
-          PlayFabID: payload.mid || payload.pfbid || payload.playFabId || payload.PlayFabID,
-          PlayFabTitleID: payload.tid || payload.pfbtid || payload.playFabTitleId || payload.PlayFabTitleID
-        }
-      }
+      key: result.clientPublicKeyBase64,
+      userData: { extraData: result.identity },
+      skinData: result.clientData,
+      authentication: result.authentication
     }
   }
 
-  async function verifyAuth (chain, token) {
-    // In 1.26.10+, the verified multiplayer token is authoritative even if a
-    // legacy certificate chain is also present.
-    if (token) return parseTokenData(token)
-
-    if (!Array.isArray(chain) || (chain.length !== 1 && chain.length !== 3)) {
-      throw new Error(`Unexpected login chain length ${chain?.length ?? 0}`)
-    }
-    if (!options.offline && chain.length !== 3) {
-      throw new Error('Authenticated legacy login requires a three-token chain')
-    }
-
-    // The first token is self-signed by the client key carried in its x5u.
-    // Its verified payload must advance the chain to Mojang's pinned key.
-    let publicKey = getDER(getX5U(chain[0]))
-    const mojangKey = getDER(dependencies.mojangPublicKey || constants.PUBLIC_KEY)
-    let authenticated = false
-    let finalKey
-    let data
-
-    for (let index = 0; index < chain.length; index++) {
-      const verifyOptions = { algorithms: ['ES384'] }
-      if (index > 0) verifyOptions.issuer = 'Mojang'
-      data = JWT.verify(chain[index], publicKey, verifyOptions)
-
-      if (!data.identityPublicKey) {
-        throw new Error(`Login chain token ${index} is missing identityPublicKey`)
-      }
-      finalKey = data.identityPublicKey
-      publicKey = getDER(finalKey)
-
-      if (index === 0) {
-        authenticated = samePublicKey(publicKey, mojangKey)
-        if (!options.offline && !authenticated) {
-          throw new Error('Legacy login chain is not anchored by Mojang')
-        }
-      }
-    }
-
-    if (!data?.extraData) throw new Error('Legacy login chain is missing identity data')
-    if (authenticated && !data.extraData.XUID) {
-      throw new Error('Authenticated legacy identity is missing XUID')
-    }
-
-    debug('Verified legacy login chain', { authenticated })
-    return { key: finalKey, data }
-  }
-
-  function verifySkin (publicKey, token) {
-    const pubKey = getDER(publicKey)
-    const decoded = JWT.verify(token, pubKey, { algorithms: ['ES384'] })
-    return decoded
-  }
-
-  client.decodeLoginJWT = async (authTokens, skinTokens, authToken = '') => {
-    const { key, data } = await verifyAuth(authTokens, authToken)
-    const skinData = verifySkin(key, skinTokens)
-    return { key, userData: data, skinData }
-  }
-
-  client.encodeLoginJWT = (localChain, mojangChain) => {
-    const chains = []
-    chains.push(localChain)
-    for (const chain of mojangChain) {
-      chains.push(chain)
-    }
-    return chains
-  }
-}
-
-function identityFromXuid (xuid) {
-  const hash = crypto.createHash('md5').update('pocket-auth-1-xuid:').update(xuid).digest()
-  hash[6] = (hash[6] & 0x0f) | 0x30
-  hash[8] = (hash[8] & 0x3f) | 0x80
-  return UUID.stringify(hash)
-}
-
-function getX5U (token) {
-  const [header] = token.split('.')
-  const hdec = Buffer.from(header, 'base64').toString('utf-8')
-  const hjson = JSON.parse(hdec)
-  return hjson.x5u
+  client.encodeLoginJWT = (localChain, mojangChain) => [localChain, ...mojangChain]
 }

--- a/src/handshake/loginVerify.js
+++ b/src/handshake/loginVerify.js
@@ -1,24 +1,5 @@
 const { createLoginVerifier } = require('../auth/loginVerifier')
 
-// Install direct verification methods while preserving decodeLoginJWT for
-// callers using the older API shape.
 module.exports = (client, server, options, dependencies = {}) => {
-  const verifier = createLoginVerifier(options, dependencies)
-  client.verifyLogin = verifier.verifyLogin
-
-  client.decodeLoginJWT = async (authTokens, skinToken, authToken = '') => {
-    const result = await client.verifyLogin({
-      chain: authTokens,
-      multiplayerToken: authToken,
-      clientDataToken: skinToken
-    })
-    return {
-      key: result.clientPublicKeyBase64,
-      userData: { extraData: result.identity },
-      skinData: result.clientData,
-      authentication: result.authentication
-    }
-  }
-
-  client.encodeLoginJWT = (localChain, mojangChain) => [localChain, ...mojangChain]
+  client.verifyLogin = createLoginVerifier(options, dependencies).verifyLogin
 }

--- a/src/handshake/loginVerify.js
+++ b/src/handshake/loginVerify.js
@@ -10,6 +10,7 @@ module.exports = (client, server, options, dependencies = {}) => {
   // https://web.archive.org/web/20180917171505if_/https://confluence.yawk.at/display/PEPROTOCOL/Game+Packets#GamePackets-Login
 
   const getDER = b64 => crypto.createPublicKey({ key: Buffer.from(b64, 'base64'), format: 'der', type: 'spki' })
+  const samePublicKey = (left, right) => left.export({ format: 'der', type: 'spki' }).equals(right.export({ format: 'der', type: 'spki' }))
 
   // 26.10, March 2026+
   async function parseTokenData (token) {
@@ -47,42 +48,50 @@ module.exports = (client, server, options, dependencies = {}) => {
   }
 
   async function verifyAuth (chain, token) {
-    // In 26.10+, identity may be carried by the multiplayer token with no certificate chain.
-    if ((!chain || chain.length === 0 || chain.every(entry => !entry)) && token) {
-      return parseTokenData(token)
+    // In 1.26.10+, the verified multiplayer token is authoritative even if a
+    // legacy certificate chain is also present.
+    if (token) return parseTokenData(token)
+
+    if (!Array.isArray(chain) || (chain.length !== 1 && chain.length !== 3)) {
+      throw new Error(`Unexpected login chain length ${chain?.length ?? 0}`)
+    }
+    if (!options.offline && chain.length !== 3) {
+      throw new Error('Authenticated legacy login requires a three-token chain')
     }
 
-    let data = {}
+    // The first token is self-signed by the client key carried in its x5u.
+    // Its verified payload must advance the chain to Mojang's pinned key.
+    let publicKey = getDER(getX5U(chain[0]))
+    const mojangKey = getDER(dependencies.mojangPublicKey || constants.PUBLIC_KEY)
+    let authenticated = false
+    let finalKey
+    let data
 
-    // There are three JWT tokens sent to us, one signed by the client
-    // one signed by Mojang with the Mojang token we have and another one
-    // from Xbox with addition user profile data
-    // We verify that at least one of the tokens in the chain has been properly
-    // signed by Mojang by checking the x509 public key in the JWT headers
-    let didVerify = false
+    for (let index = 0; index < chain.length; index++) {
+      const verifyOptions = { algorithms: ['ES384'] }
+      if (index > 0) verifyOptions.issuer = 'Mojang'
+      data = JWT.verify(chain[index], publicKey, verifyOptions)
 
-    let pubKey = getDER(getX5U(chain[0])) // the first one is client signed, allow it
-    let finalKey = null
-
-    for (const token of chain) {
-      const decoded = JWT.verify(token, pubKey, { algorithms: ['ES384'] })
-
-      // Check if signed by Mojang key
-      const x5u = getX5U(token)
-      if (x5u === constants.PUBLIC_KEY && !data.extraData?.XUID) {
-        didVerify = true
-        debug('Verified client with mojang key', x5u)
+      if (!data.identityPublicKey) {
+        throw new Error(`Login chain token ${index} is missing identityPublicKey`)
       }
+      finalKey = data.identityPublicKey
+      publicKey = getDER(finalKey)
 
-      pubKey = decoded.identityPublicKey ? getDER(decoded.identityPublicKey) : x5u
-      finalKey = decoded.identityPublicKey || finalKey // non pem
-      data = { ...data, ...decoded }
+      if (index === 0) {
+        authenticated = samePublicKey(publicKey, mojangKey)
+        if (!options.offline && !authenticated) {
+          throw new Error('Legacy login chain is not anchored by Mojang')
+        }
+      }
     }
 
-    if (!didVerify && !options.offline) {
-      client.disconnect('disconnectionScreen.notAuthenticated')
+    if (!data?.extraData) throw new Error('Legacy login chain is missing identity data')
+    if (authenticated && !data.extraData.XUID) {
+      throw new Error('Authenticated legacy identity is missing XUID')
     }
 
+    debug('Verified legacy login chain', { authenticated })
     return { key: finalKey, data }
   }
 

--- a/src/serverPlayer.js
+++ b/src/serverPlayer.js
@@ -36,6 +36,8 @@ class Player extends Connection {
     this.compressionHeader = this.server.compressionHeader
 
     this._sentNetworkSettings = false // 1.19.30+
+    this.loginStarted = false
+    this.awaitingClientHandshake = false
   }
 
   getUserData () {
@@ -68,6 +70,12 @@ class Player extends Connection {
   }
 
   async onLogin (packet) {
+    if (this.loginStarted) {
+      this.disconnect('Server authentication error')
+      return
+    }
+    this.loginStarted = true
+
     const body = packet.data
     this.emit('loggingIn', body)
 
@@ -100,8 +108,6 @@ class Player extends Connection {
       return
     }
 
-    this.emit('server.client_handshake', { key }) // internal so we start encryption
-
     this.userData = userData.extraData
     this.skinData = skinData
     this.profile = {
@@ -110,6 +116,8 @@ class Player extends Connection {
       xuid: userData.extraData?.xuid || userData.extraData?.XUID
     }
     this.version = clientVer
+    this.awaitingClientHandshake = true
+    this.emit('server.client_handshake', { key }) // internal so we start encryption
     this.emit('login', { user: userData.extraData }) // emit events for user
   }
 
@@ -140,10 +148,17 @@ class Player extends Connection {
   // After sending Server to Client Handshake, this handles the client's
   // Client to Server handshake response. This indicates successful encryption
   onHandshake () {
+    if (this.status !== ClientStatus.Authenticating || !this.awaitingClientHandshake || !this.encryptionEnabled) {
+      this.disconnect('Server authentication error')
+      return false
+    }
+    this.awaitingClientHandshake = false
+
     // https://wiki.vg/Bedrock_Protocol#Play_Status
     this.write('play_status', { status: 'login_success' })
     this.status = ClientStatus.Initializing
     this.emit('join')
+    return true
   }
 
   close (reason) {
@@ -185,9 +200,13 @@ class Player extends Connection {
         return
       case 'client_to_server_handshake':
         // Emit the 'join' event
-        this.onHandshake()
+        if (!this.onHandshake()) return
         break
       case 'set_local_player_as_initialized':
+        if (this.status !== ClientStatus.Initializing) {
+          this.disconnect('Server authentication error')
+          return
+        }
         this.status = ClientStatus.Initialized
         this.inLog?.('Server client spawned')
         // Emit the 'spawn' event

--- a/src/serverPlayer.js
+++ b/src/serverPlayer.js
@@ -4,6 +4,9 @@ const { serialize, isDebug } = require('./datatypes/util')
 const { createKeyExchange } = require('./handshake/keyExchange')
 const Login = require('./handshake/login')
 const LoginVerify = require('./handshake/loginVerify')
+const { createLoginVerifier } = require('./auth/loginVerifier')
+const { parseLoginEnvelope } = require('./auth/loginEnvelope')
+const { LoginPhase, LoginState } = require('./auth/loginState')
 const debug = require('debug')('minecraft-protocol')
 
 class Player extends Connection {
@@ -22,7 +25,8 @@ class Player extends Connection {
     this.privateKeyPEM = this.keyExchange.privateKeyPEM
     this.clientX509 = this.keyExchange.clientX509
     Login(this, server, server.options)
-    LoginVerify(this, server, server.options)
+    this.loginVerifier = createLoginVerifier(server.options)
+    LoginVerify(this, server, server.options, { loginVerifier: this.loginVerifier })
 
     this.startQueue()
     this.status = ClientStatus.Authenticating
@@ -40,8 +44,7 @@ class Player extends Connection {
     this.compressionHeader = this.server.compressionHeader
 
     this._sentNetworkSettings = false // 1.19.30+
-    this.loginStarted = false
-    this.awaitingClientHandshake = false
+    this.loginState = new LoginState()
   }
 
   getUserData () {
@@ -74,57 +77,42 @@ class Player extends Connection {
   }
 
   async onLogin (packet) {
-    if (this.loginStarted) {
-      this.disconnect('Server authentication error')
-      return
-    }
-    this.loginStarted = true
-
-    const body = packet.data
-    this.emit('loggingIn', body)
-
-    const clientVer = body.params.protocol_version
-    if (!this.handleClientProtocolVersion(clientVer)) {
-      return
-    }
-
-    // Parse login data
-    const tokens = body.params.tokens
     try {
-      const skinChain = tokens.client
-      const authChain = JSON.parse(tokens.identity)
-      const authToken = authChain.Token || ''
-      if (authChain.AuthenticationType === 1) throw new Error('Guest authentication is not supported')
-      let chain
-      if (authChain.Certificate) { // 1.21.90+
-        chain = JSON.parse(authChain.Certificate).chain
-      } else if (authChain.chain) {
-        chain = authChain.chain
-      } else if (authToken) {
-        chain = []
-      } else {
-        throw new Error('Invalid login packet: missing chain or Certificate')
-      }
-      var { key, userData, skinData } = await this.decodeLoginJWT(chain, skinChain, authToken) // eslint-disable-line
-    } catch (e) {
-      debug(this.address, e)
-      this.disconnect('Server authentication error')
-      return
-    }
+      this.loginState.transition(LoginPhase.VerifyingLogin)
+      this.emit('loggingIn', packet.data)
 
-    this.userData = userData.extraData
-    this.skinData = skinData
-    this.profile = {
-      name: userData.extraData?.displayName,
-      uuid: userData.extraData?.identity,
-      xuid: userData.extraData?.xuid || userData.extraData?.XUID
+      const envelope = parseLoginEnvelope(packet)
+      if (!this.handleClientProtocolVersion(envelope.protocolVersion)) {
+        this.loginState.reject()
+        return
+      }
+
+      const verified = await this.loginVerifier.verifyLogin(envelope)
+      this.loginState.require(LoginPhase.VerifyingLogin)
+      this.authentication = verified.authentication
+      this.userData = verified.identity
+      this.skinData = verified.clientData
+      this.profile = {
+        name: verified.identity.displayName,
+        uuid: verified.identity.identity,
+        xuid: verified.identity.XUID
+      }
+      this.version = envelope.protocolVersion
+
+      const handshake = this.keyExchange.createServerHandshake(verified.clientPublicKey)
+      this.write('server_to_client_handshake', { token: handshake.token })
+      this.enableEncryption(handshake)
+      this.loginState.transition(LoginPhase.AwaitingClientHandshake)
+      this.emit('login', { user: verified.identity, authentication: verified.authentication })
+    } catch (e) {
+      this.rejectLogin(e)
     }
-    this.version = clientVer
-    const handshake = this.keyExchange.createServerHandshake(key)
-    this.write('server_to_client_handshake', { token: handshake.token })
-    this.enableEncryption(handshake)
-    this.awaitingClientHandshake = true
-    this.emit('login', { user: userData.extraData }) // emit events for user
+  }
+
+  rejectLogin (error) {
+    if (!this.loginState.reject()) return
+    debug(this.address, error)
+    this.disconnect('Server authentication error')
   }
 
   /**
@@ -154,15 +142,20 @@ class Player extends Connection {
   // After sending Server to Client Handshake, this handles the client's
   // Client to Server handshake response. This indicates successful encryption
   onHandshake () {
-    if (this.status !== ClientStatus.Authenticating || !this.awaitingClientHandshake || !this.encryptionEnabled) {
-      this.disconnect('Server authentication error')
+    try {
+      this.loginState.require(LoginPhase.AwaitingClientHandshake)
+      if (this.status !== ClientStatus.Authenticating || !this.encryptionEnabled) {
+        throw new Error('Client handshake arrived before encryption was enabled')
+      }
+      this.loginState.transition(LoginPhase.Complete)
+    } catch (error) {
+      this.rejectLogin(error)
       return false
     }
-    this.awaitingClientHandshake = false
 
     // https://wiki.vg/Bedrock_Protocol#Play_Status
-    this.write('play_status', { status: 'login_success' })
     this.status = ClientStatus.Initializing
+    this.write('play_status', { status: 'login_success' })
     this.emit('join')
     return true
   }
@@ -178,9 +171,12 @@ class Player extends Connection {
     this.connection?.close()
     this.removeAllListeners()
     this.status = ClientStatus.Disconnected
+    this.loginState?.close()
   }
 
   readPacket (packet) {
+    if (this.loginState.is(LoginPhase.Rejected) || this.loginState.is(LoginPhase.Closed)) return
+
     try {
       var des = this.server.deserializer.parsePacketBuffer(packet) // eslint-disable-line
     } catch (e) {
@@ -194,6 +190,10 @@ class Player extends Connection {
     switch (des.data.name) {
       // This is the first packet on 1.19.30 & above
       case 'request_network_settings':
+        if (!this.loginState.is(LoginPhase.AwaitingLogin)) {
+          this.rejectLogin(new Error('Network settings request arrived after login started'))
+          return
+        }
         if (this.handleClientProtocolVersion(des.data.params.client_protocol)) {
           this.sendNetworkSettings()
           this.compressionLevel = this.server.compressionLevel
@@ -201,7 +201,7 @@ class Player extends Connection {
         return
       // Below 1.19.30, this is the first packet.
       case 'login':
-        this.onLogin(des)
+        void this.onLogin(des)
         if (!this._sentNetworkSettings) this.sendNetworkSettings()
         return
       case 'client_to_server_handshake':
@@ -209,8 +209,8 @@ class Player extends Connection {
         if (!this.onHandshake()) return
         break
       case 'set_local_player_as_initialized':
-        if (this.status !== ClientStatus.Initializing) {
-          this.disconnect('Server authentication error')
+        if (!this.loginState.is(LoginPhase.Complete) || this.status !== ClientStatus.Initializing) {
+          this.rejectLogin(new Error('Player initialization arrived before login completed'))
           return
         }
         this.status = ClientStatus.Initialized
@@ -219,7 +219,7 @@ class Player extends Connection {
         this.emit('spawn')
         break
       default:
-        if (this.status === ClientStatus.Disconnected || this.status === ClientStatus.Authenticating) {
+        if (!this.loginState.is(LoginPhase.Complete) || this.status === ClientStatus.Disconnected || this.status === ClientStatus.Authenticating) {
           this.inLog?.('ignoring', des.data.name)
           return
         }

--- a/src/serverPlayer.js
+++ b/src/serverPlayer.js
@@ -79,9 +79,10 @@ class Player extends Connection {
   async onLogin (packet) {
     try {
       this.loginState.transition(LoginPhase.VerifyingLogin)
-      this.emit('loggingIn', packet.data)
-
       const envelope = parseLoginEnvelope(packet)
+      // Compatibility notification containing raw, unverified input. Parsing
+      // happens first so listeners cannot alter what the verifier consumes.
+      this.emit('loggingIn', packet.data)
       if (!this.handleClientProtocolVersion(envelope.protocolVersion)) {
         this.loginState.reject()
         return
@@ -201,7 +202,7 @@ class Player extends Connection {
         return
       // Below 1.19.30, this is the first packet.
       case 'login':
-        void this.onLogin(des)
+        this.onLogin(des).catch(error => this.rejectLogin(error))
         if (!this._sentNetworkSettings) this.sendNetworkSettings()
         return
       case 'client_to_server_handshake':

--- a/src/serverPlayer.js
+++ b/src/serverPlayer.js
@@ -51,6 +51,10 @@ class Player extends Connection {
     return this.userData
   }
 
+  getAuthentication () {
+    return this.authentication
+  }
+
   sendNetworkSettings () {
     this.write('network_settings', {
       compression_threshold: this.server.compressionThreshold,

--- a/src/serverPlayer.js
+++ b/src/serverPlayer.js
@@ -4,7 +4,6 @@ const { serialize, isDebug } = require('./datatypes/util')
 const { createKeyExchange } = require('./handshake/keyExchange')
 const Login = require('./handshake/login')
 const LoginVerify = require('./handshake/loginVerify')
-const { createLoginVerifier } = require('./auth/loginVerifier')
 const { parseLoginEnvelope } = require('./auth/loginEnvelope')
 const { LoginPhase, LoginState } = require('./auth/loginState')
 const debug = require('debug')('minecraft-protocol')
@@ -19,14 +18,9 @@ class Player extends Connection {
     this.connection = connection
     this.options = server.options
 
-    this.keyExchange = createKeyExchange()
-    this.ecdhKeyPair = this.keyExchange.keyPair
-    this.publicKeyDER = this.keyExchange.publicKeyDER
-    this.privateKeyPEM = this.keyExchange.privateKeyPEM
-    this.clientX509 = this.keyExchange.clientX509
+    createKeyExchange(this)
     Login(this, server, server.options)
-    this.loginVerifier = createLoginVerifier(server.options)
-    LoginVerify(this, server, server.options, { loginVerifier: this.loginVerifier })
+    LoginVerify(this, server, server.options)
 
     this.startQueue()
     this.status = ClientStatus.Authenticating
@@ -49,10 +43,6 @@ class Player extends Connection {
 
   getUserData () {
     return this.userData
-  }
-
-  getAuthentication () {
-    return this.authentication
   }
 
   sendNetworkSettings () {
@@ -84,15 +74,13 @@ class Player extends Connection {
     try {
       this.loginState.transition(LoginPhase.VerifyingLogin)
       const envelope = parseLoginEnvelope(packet)
-      // Compatibility notification containing raw, unverified input. Parsing
-      // happens first so listeners cannot alter what the verifier consumes.
       this.emit('loggingIn', packet.data)
       if (!this.handleClientProtocolVersion(envelope.protocolVersion)) {
         this.loginState.reject()
         return
       }
 
-      const verified = await this.loginVerifier.verifyLogin(envelope)
+      const verified = await this.verifyLogin(envelope)
       this.loginState.require(LoginPhase.VerifyingLogin)
       this.authentication = verified.authentication
       this.userData = verified.identity
@@ -104,7 +92,7 @@ class Player extends Connection {
       }
       this.version = envelope.protocolVersion
 
-      const handshake = this.keyExchange.createServerHandshake(verified.clientPublicKey)
+      const handshake = this.createServerHandshake(verified.clientPublicKey)
       this.write('server_to_client_handshake', { token: handshake.token })
       this.enableEncryption(handshake)
       this.loginState.transition(LoginPhase.AwaitingClientHandshake)

--- a/src/serverPlayer.js
+++ b/src/serverPlayer.js
@@ -1,7 +1,7 @@
 const { ClientStatus, Connection } = require('./connection')
 const Options = require('./options')
 const { serialize, isDebug } = require('./datatypes/util')
-const { KeyExchange } = require('./handshake/keyExchange')
+const { createKeyExchange } = require('./handshake/keyExchange')
 const Login = require('./handshake/login')
 const LoginVerify = require('./handshake/loginVerify')
 const debug = require('debug')('minecraft-protocol')
@@ -16,7 +16,11 @@ class Player extends Connection {
     this.connection = connection
     this.options = server.options
 
-    KeyExchange(this, server, server.options)
+    this.keyExchange = createKeyExchange()
+    this.ecdhKeyPair = this.keyExchange.keyPair
+    this.publicKeyDER = this.keyExchange.publicKeyDER
+    this.privateKeyPEM = this.keyExchange.privateKeyPEM
+    this.clientX509 = this.keyExchange.clientX509
     Login(this, server, server.options)
     LoginVerify(this, server, server.options)
 
@@ -116,8 +120,10 @@ class Player extends Connection {
       xuid: userData.extraData?.xuid || userData.extraData?.XUID
     }
     this.version = clientVer
+    const handshake = this.keyExchange.createServerHandshake(key)
+    this.write('server_to_client_handshake', { token: handshake.token })
+    this.enableEncryption(handshake)
     this.awaitingClientHandshake = true
-    this.emit('server.client_handshake', { key }) // internal so we start encryption
     this.emit('login', { user: userData.extraData }) // emit events for user
   }
 

--- a/src/serverPlayer.js
+++ b/src/serverPlayer.js
@@ -1,7 +1,7 @@
 const { ClientStatus, Connection } = require('./connection')
 const Options = require('./options')
 const { serialize, isDebug } = require('./datatypes/util')
-const { createKeyExchange } = require('./handshake/keyExchange')
+const KeyExchange = require('./handshake/keyExchange')
 const Login = require('./handshake/login')
 const LoginVerify = require('./handshake/loginVerify')
 const { parseLoginEnvelope } = require('./auth/loginEnvelope')
@@ -18,7 +18,7 @@ class Player extends Connection {
     this.connection = connection
     this.options = server.options
 
-    createKeyExchange(this)
+    KeyExchange(this)
     Login(this, server, server.options)
     LoginVerify(this, server, server.options)
 

--- a/test/keyExchange.test.js
+++ b/test/keyExchange.test.js
@@ -3,7 +3,7 @@
 const assert = require('assert')
 const crypto = require('crypto')
 const JWT = require('jsonwebtoken')
-const { createKeyExchange } = require('../src/handshake/keyExchange')
+const KeyExchange = require('../src/handshake/keyExchange')
 
 function publicKeyBase64 (key) {
   return key.export({ format: 'der', type: 'spki' }).toString('base64')
@@ -11,7 +11,7 @@ function publicKeyBase64 (key) {
 
 function exchange () {
   const client = {}
-  createKeyExchange(client)
+  KeyExchange(client)
   return client
 }
 

--- a/test/keyExchange.test.js
+++ b/test/keyExchange.test.js
@@ -9,13 +9,19 @@ function publicKeyBase64 (key) {
   return key.export({ format: 'der', type: 'spki' }).toString('base64')
 }
 
+function exchange () {
+  const client = {}
+  createKeyExchange(client)
+  return client
+}
+
 describe('key exchange', () => {
   it('generates a fresh server salt for every handshake', () => {
     const remote = crypto.generateKeyPairSync('ec', { namedCurve: 'P-384' })
-    const exchange = createKeyExchange()
+    const keyExchange = exchange()
 
-    const first = exchange.createServerHandshake(remote.publicKey)
-    const second = exchange.createServerHandshake(remote.publicKey)
+    const first = keyExchange.createServerHandshake(remote.publicKey)
+    const second = keyExchange.createServerHandshake(remote.publicKey)
 
     const salts = [first, second].map(handshake => JWT.decode(handshake.token).salt)
     assert.notStrictEqual(salts[0], salts[1])
@@ -31,16 +37,16 @@ describe('key exchange', () => {
       algorithm: 'ES384',
       header: { x5u: serverPublicKey, typ: undefined }
     })
-    const exchange = createKeyExchange()
+    const keyExchange = exchange()
 
-    assert.throws(() => exchange.verifyServerHandshake({ token: forged }), /invalid signature/)
+    assert.throws(() => keyExchange.verifyServerHandshake({ token: forged }), /invalid signature/)
   })
 
   it('derives matching encryption material from a valid handshake', () => {
-    const server = createKeyExchange()
-    const client = createKeyExchange()
+    const server = exchange()
+    const client = exchange()
 
-    const outbound = server.createServerHandshake(client.keyPair.publicKey)
+    const outbound = server.createServerHandshake(client.ecdhKeyPair.publicKey)
     const inbound = client.verifyServerHandshake({ token: outbound.token })
 
     assert.deepStrictEqual(inbound.secretKeyBytes, outbound.secretKeyBytes)
@@ -55,8 +61,8 @@ describe('key exchange', () => {
       algorithm: 'ES384',
       header: { x5u: serverPublicKey, typ: undefined }
     })
-    const exchange = createKeyExchange()
+    const keyExchange = exchange()
 
-    assert.throws(() => exchange.verifyServerHandshake({ token }), /invalid length/)
+    assert.throws(() => keyExchange.verifyServerHandshake({ token }), /invalid length/)
   })
 })

--- a/test/keyExchange.test.js
+++ b/test/keyExchange.test.js
@@ -1,0 +1,75 @@
+/* eslint-env mocha */
+
+const assert = require('assert')
+const crypto = require('crypto')
+const { EventEmitter } = require('events')
+const JWT = require('jsonwebtoken')
+const { KeyExchange } = require('../src/handshake/keyExchange')
+
+function publicKeyBase64 (key) {
+  return key.export({ format: 'der', type: 'spki' }).toString('base64')
+}
+
+function createConnection () {
+  const client = new EventEmitter()
+  client.write = (name, params) => client.writes.push([name, params])
+  client.startEncryption = iv => {
+    client.encryptionIv = iv
+    client.encryptionEnabled = true
+  }
+  client.writes = []
+  KeyExchange(client)
+  return client
+}
+
+describe('key exchange', () => {
+  it('generates a fresh server salt for every handshake', () => {
+    const remote = crypto.generateKeyPairSync('ec', { namedCurve: 'P-384' })
+    const client = createConnection()
+
+    client.emit('server.client_handshake', { key: publicKeyBase64(remote.publicKey) })
+    client.emit('server.client_handshake', { key: publicKeyBase64(remote.publicKey) })
+
+    const salts = client.writes.map(([, packet]) => JWT.decode(packet.token).salt)
+    assert.strictEqual(salts.length, 2)
+    assert.notStrictEqual(salts[0], salts[1])
+    assert.strictEqual(Buffer.from(salts[0], 'base64').length, 16)
+    assert.strictEqual(Buffer.from(salts[1], 'base64').length, 16)
+  })
+
+  it('verifies the server handshake signature before enabling encryption', () => {
+    const server = crypto.generateKeyPairSync('ec', { namedCurve: 'P-384' })
+    const attacker = crypto.generateKeyPairSync('ec', { namedCurve: 'P-384' })
+    const serverPublicKey = publicKeyBase64(server.publicKey)
+    const salt = crypto.randomBytes(16).toString('base64')
+    const forged = JWT.sign({ salt }, attacker.privateKey, {
+      algorithm: 'ES384',
+      header: { x5u: serverPublicKey, typ: undefined }
+    })
+    const client = createConnection()
+    let joined = false
+    client.on('join', () => { joined = true })
+
+    assert.throws(() => client.emit('client.server_handshake', { token: forged }), /invalid signature/)
+    assert.strictEqual(client.encryptionEnabled, undefined)
+    assert.strictEqual(joined, false)
+  })
+
+  it('accepts a correctly self-signed server handshake', () => {
+    const server = crypto.generateKeyPairSync('ec', { namedCurve: 'P-384' })
+    const serverPublicKey = publicKeyBase64(server.publicKey)
+    const token = JWT.sign({ salt: crypto.randomBytes(16).toString('base64') }, server.privateKey, {
+      algorithm: 'ES384',
+      header: { x5u: serverPublicKey, typ: undefined }
+    })
+    const client = createConnection()
+    let joined = false
+    client.on('join', () => { joined = true })
+
+    client.emit('client.server_handshake', { token })
+
+    assert.strictEqual(client.encryptionEnabled, true)
+    assert.strictEqual(client.writes.at(-1)[0], 'client_to_server_handshake')
+    assert.strictEqual(joined, true)
+  })
+})

--- a/test/keyExchange.test.js
+++ b/test/keyExchange.test.js
@@ -2,74 +2,61 @@
 
 const assert = require('assert')
 const crypto = require('crypto')
-const { EventEmitter } = require('events')
 const JWT = require('jsonwebtoken')
-const { KeyExchange } = require('../src/handshake/keyExchange')
+const { createKeyExchange } = require('../src/handshake/keyExchange')
 
 function publicKeyBase64 (key) {
   return key.export({ format: 'der', type: 'spki' }).toString('base64')
 }
 
-function createConnection () {
-  const client = new EventEmitter()
-  client.write = (name, params) => client.writes.push([name, params])
-  client.startEncryption = iv => {
-    client.encryptionIv = iv
-    client.encryptionEnabled = true
-  }
-  client.writes = []
-  KeyExchange(client)
-  return client
-}
-
 describe('key exchange', () => {
   it('generates a fresh server salt for every handshake', () => {
     const remote = crypto.generateKeyPairSync('ec', { namedCurve: 'P-384' })
-    const client = createConnection()
+    const exchange = createKeyExchange()
 
-    client.emit('server.client_handshake', { key: publicKeyBase64(remote.publicKey) })
-    client.emit('server.client_handshake', { key: publicKeyBase64(remote.publicKey) })
+    const first = exchange.createServerHandshake(remote.publicKey)
+    const second = exchange.createServerHandshake(remote.publicKey)
 
-    const salts = client.writes.map(([, packet]) => JWT.decode(packet.token).salt)
-    assert.strictEqual(salts.length, 2)
+    const salts = [first, second].map(handshake => JWT.decode(handshake.token).salt)
     assert.notStrictEqual(salts[0], salts[1])
     assert.strictEqual(Buffer.from(salts[0], 'base64').length, 16)
     assert.strictEqual(Buffer.from(salts[1], 'base64').length, 16)
   })
 
-  it('verifies the server handshake signature before enabling encryption', () => {
+  it('verifies the server handshake signature before deriving encryption', () => {
     const server = crypto.generateKeyPairSync('ec', { namedCurve: 'P-384' })
     const attacker = crypto.generateKeyPairSync('ec', { namedCurve: 'P-384' })
     const serverPublicKey = publicKeyBase64(server.publicKey)
-    const salt = crypto.randomBytes(16).toString('base64')
-    const forged = JWT.sign({ salt }, attacker.privateKey, {
+    const forged = JWT.sign({ salt: crypto.randomBytes(16).toString('base64') }, attacker.privateKey, {
       algorithm: 'ES384',
       header: { x5u: serverPublicKey, typ: undefined }
     })
-    const client = createConnection()
-    let joined = false
-    client.on('join', () => { joined = true })
+    const exchange = createKeyExchange()
 
-    assert.throws(() => client.emit('client.server_handshake', { token: forged }), /invalid signature/)
-    assert.strictEqual(client.encryptionEnabled, undefined)
-    assert.strictEqual(joined, false)
+    assert.throws(() => exchange.verifyServerHandshake({ token: forged }), /invalid signature/)
   })
 
-  it('accepts a correctly self-signed server handshake', () => {
+  it('derives matching encryption material from a valid handshake', () => {
+    const server = createKeyExchange()
+    const client = createKeyExchange()
+
+    const outbound = server.createServerHandshake(client.keyPair.publicKey)
+    const inbound = client.verifyServerHandshake({ token: outbound.token })
+
+    assert.deepStrictEqual(inbound.secretKeyBytes, outbound.secretKeyBytes)
+    assert.deepStrictEqual(inbound.iv, outbound.iv)
+    assert.deepStrictEqual(inbound.sharedSecret, outbound.sharedSecret)
+  })
+
+  it('rejects oversized handshake salts', () => {
     const server = crypto.generateKeyPairSync('ec', { namedCurve: 'P-384' })
     const serverPublicKey = publicKeyBase64(server.publicKey)
-    const token = JWT.sign({ salt: crypto.randomBytes(16).toString('base64') }, server.privateKey, {
+    const token = JWT.sign({ salt: crypto.randomBytes(65).toString('base64') }, server.privateKey, {
       algorithm: 'ES384',
       header: { x5u: serverPublicKey, typ: undefined }
     })
-    const client = createConnection()
-    let joined = false
-    client.on('join', () => { joined = true })
+    const exchange = createKeyExchange()
 
-    client.emit('client.server_handshake', { token })
-
-    assert.strictEqual(client.encryptionEnabled, true)
-    assert.strictEqual(client.writes.at(-1)[0], 'client_to_server_handshake')
-    assert.strictEqual(joined, true)
+    assert.throws(() => exchange.verifyServerHandshake({ token }), /invalid length/)
   })
 })

--- a/test/loginEnvelope.test.js
+++ b/test/loginEnvelope.test.js
@@ -22,7 +22,6 @@ describe('login envelope parsing', () => {
     const legacy = parseLoginEnvelope(packet({ chain: ['one'] }))
     assert.deepStrictEqual(legacy, {
       protocolVersion: 123,
-      authenticationType: undefined,
       chain: ['one'],
       multiplayerToken: '',
       clientDataToken: 'client-data'
@@ -35,7 +34,6 @@ describe('login envelope parsing', () => {
     }))
     assert.deepStrictEqual(modern, {
       protocolVersion: 123,
-      authenticationType: 0,
       chain: ['one', 'two', 'three'],
       multiplayerToken: 'oidc-token',
       clientDataToken: 'client-data'

--- a/test/loginEnvelope.test.js
+++ b/test/loginEnvelope.test.js
@@ -1,0 +1,53 @@
+/* eslint-env mocha */
+
+const assert = require('assert')
+const { parseLoginEnvelope } = require('../src/auth/loginEnvelope')
+
+function packet (identity, client = 'client-data') {
+  return {
+    data: {
+      params: {
+        protocol_version: 123,
+        tokens: {
+          identity: typeof identity === 'string' ? identity : JSON.stringify(identity),
+          client
+        }
+      }
+    }
+  }
+}
+
+describe('login envelope parsing', () => {
+  it('parses legacy and modern certificate shapes without making trust decisions', () => {
+    const legacy = parseLoginEnvelope(packet({ chain: ['one'] }))
+    assert.deepStrictEqual(legacy, {
+      protocolVersion: 123,
+      authenticationType: undefined,
+      chain: ['one'],
+      multiplayerToken: '',
+      clientDataToken: 'client-data'
+    })
+
+    const modern = parseLoginEnvelope(packet({
+      AuthenticationType: 0,
+      Certificate: JSON.stringify({ chain: ['one', 'two', 'three'] }),
+      Token: 'oidc-token'
+    }))
+    assert.deepStrictEqual(modern, {
+      protocolVersion: 123,
+      authenticationType: 0,
+      chain: ['one', 'two', 'three'],
+      multiplayerToken: 'oidc-token',
+      clientDataToken: 'client-data'
+    })
+  })
+
+  it('rejects guest, malformed, and incomplete envelopes', () => {
+    assert.throws(() => parseLoginEnvelope(packet({ AuthenticationType: 1, Token: 'value' })), /Guest authentication/)
+    assert.throws(() => parseLoginEnvelope(packet('{not-json')), /invalid JSON/)
+    assert.throws(() => parseLoginEnvelope(packet({ Certificate: '{not-json' })), /Certificate is invalid JSON/)
+    assert.throws(() => parseLoginEnvelope(packet({})), /missing its chain or Certificate/)
+    assert.throws(() => parseLoginEnvelope(packet({ chain: 'not-an-array' })), /chain must be an array/)
+    assert.throws(() => parseLoginEnvelope(packet({ chain: [] }, '')), /missing its client-data token/)
+  })
+})

--- a/test/loginState.test.js
+++ b/test/loginState.test.js
@@ -42,15 +42,13 @@ function fakePlayer (verifyLogin) {
     address: 'local-state-test',
     status: ClientStatus.Authenticating,
     loginState: new LoginState(),
-    loginVerifier: { verifyLogin },
-    keyExchange: {
-      createServerHandshake: () => ({
-        token: 'server-handshake',
-        sharedSecret: Buffer.alloc(48),
-        secretKeyBytes: Buffer.alloc(32),
-        iv: Buffer.alloc(16)
-      })
-    },
+    verifyLogin,
+    createServerHandshake: () => ({
+      token: 'server-handshake',
+      sharedSecret: Buffer.alloc(48),
+      secretKeyBytes: Buffer.alloc(32),
+      iv: Buffer.alloc(16)
+    }),
     handleClientProtocolVersion: () => true,
     write: (name, params) => writes.push([name, params]),
     enableEncryption: () => { player.encryptionEnabled = true },

--- a/test/loginState.test.js
+++ b/test/loginState.test.js
@@ -1,0 +1,114 @@
+/* eslint-env mocha */
+
+const assert = require('assert')
+const crypto = require('crypto')
+const { ClientStatus } = require('../src/connection')
+const { Player } = require('../src/serverPlayer')
+const { LoginPhase, LoginState, ProtocolStateError } = require('../src/auth/loginState')
+
+function loginPacket () {
+  return {
+    data: {
+      params: {
+        protocol_version: 0,
+        tokens: {
+          identity: JSON.stringify({ Token: 'synthetic-token' }),
+          client: 'synthetic-client-data'
+        }
+      }
+    }
+  }
+}
+
+function verifiedLogin () {
+  const keyPair = crypto.generateKeyPairSync('ec', { namedCurve: 'P-384' })
+  return {
+    authentication: { authenticated: true, method: 'oidc', issuer: 'test' },
+    identity: {
+      XUID: '2535427801234567',
+      displayName: 'VerifiedPlayer',
+      identity: crypto.randomUUID()
+    },
+    clientPublicKey: keyPair.publicKey,
+    clientData: { DeviceOS: 7 }
+  }
+}
+
+function fakePlayer (verifyLogin) {
+  const writes = []
+  const emitted = []
+  const disconnects = []
+  const player = {
+    address: 'local-state-test',
+    status: ClientStatus.Authenticating,
+    loginState: new LoginState(),
+    loginVerifier: { verifyLogin },
+    keyExchange: {
+      createServerHandshake: () => ({
+        token: 'server-handshake',
+        sharedSecret: Buffer.alloc(48),
+        secretKeyBytes: Buffer.alloc(32),
+        iv: Buffer.alloc(16)
+      })
+    },
+    handleClientProtocolVersion: () => true,
+    write: (name, params) => writes.push([name, params]),
+    enableEncryption: () => { player.encryptionEnabled = true },
+    emit: (name, value) => emitted.push([name, value]),
+    disconnect: reason => disconnects.push(reason),
+    rejectLogin: Player.prototype.rejectLogin
+  }
+  return { player, writes, emitted, disconnects }
+}
+
+describe('login state', () => {
+  it('permits only the defined phase sequence', () => {
+    const state = new LoginState()
+    assert.strictEqual(state.phase, LoginPhase.AwaitingLogin)
+    assert.throws(() => state.transition(LoginPhase.Complete), ProtocolStateError)
+    state.transition(LoginPhase.VerifyingLogin)
+    state.transition(LoginPhase.AwaitingClientHandshake)
+    state.transition(LoginPhase.Complete)
+    state.close()
+    assert.strictEqual(state.phase, LoginPhase.Closed)
+  })
+
+  it('commits verified identity before awaiting the encrypted acknowledgement', async () => {
+    const verified = verifiedLogin()
+    const { player, writes, emitted, disconnects } = fakePlayer(async () => verified)
+
+    await Player.prototype.onLogin.call(player, loginPacket())
+
+    assert.strictEqual(player.loginState.phase, LoginPhase.AwaitingClientHandshake)
+    assert.deepStrictEqual(player.authentication, verified.authentication)
+    assert.deepStrictEqual(player.userData, verified.identity)
+    assert.strictEqual(player.encryptionEnabled, true)
+    assert.deepStrictEqual(writes.map(([name]) => name), ['server_to_client_handshake'])
+    assert.deepStrictEqual(emitted.map(([name]) => name), ['loggingIn', 'login'])
+    assert.deepStrictEqual(disconnects, [])
+
+    player.onHandshake = Player.prototype.onHandshake
+    assert.strictEqual(player.onHandshake(), true)
+    assert.strictEqual(player.loginState.phase, LoginPhase.Complete)
+    assert.strictEqual(player.status, ClientStatus.Initializing)
+    assert.deepStrictEqual(emitted.map(([name]) => name), ['loggingIn', 'login', 'join'])
+  })
+
+  it('makes duplicate login rejection terminal while verification is pending', async () => {
+    let resolveVerification
+    const pending = new Promise(resolve => { resolveVerification = resolve })
+    const { player, writes, emitted, disconnects } = fakePlayer(() => pending)
+
+    const first = Player.prototype.onLogin.call(player, loginPacket())
+    await Player.prototype.onLogin.call(player, loginPacket())
+    assert.strictEqual(player.loginState.phase, LoginPhase.Rejected)
+    assert.deepStrictEqual(disconnects, ['Server authentication error'])
+
+    resolveVerification(verifiedLogin())
+    await first
+
+    assert.strictEqual(player.loginState.phase, LoginPhase.Rejected)
+    assert.deepStrictEqual(writes, [])
+    assert.deepStrictEqual(emitted.map(([name]) => name), ['loggingIn'])
+  })
+})

--- a/test/loginState.test.js
+++ b/test/loginState.test.js
@@ -2,7 +2,7 @@
 
 const assert = require('assert')
 const crypto = require('crypto')
-const { ClientStatus } = require('../src/connection')
+const { ClientStatus, Connection } = require('../src/connection')
 const { Player } = require('../src/serverPlayer')
 const { LoginPhase, LoginState, ProtocolStateError } = require('../src/auth/loginState')
 
@@ -62,6 +62,19 @@ function fakePlayer (verifyLogin) {
 }
 
 describe('login state', () => {
+  it('publishes status only after committing the new value', () => {
+    const connection = new Connection()
+    let observed
+    connection.on('status', value => {
+      observed = { value, current: connection.status }
+    })
+    connection.status = ClientStatus.Authenticating
+    assert.deepStrictEqual(observed, {
+      value: ClientStatus.Authenticating,
+      current: ClientStatus.Authenticating
+    })
+  })
+
   it('permits only the defined phase sequence', () => {
     const state = new LoginState()
     assert.strictEqual(state.phase, LoginPhase.AwaitingLogin)
@@ -110,5 +123,20 @@ describe('login state', () => {
     assert.strictEqual(player.loginState.phase, LoginPhase.Rejected)
     assert.deepStrictEqual(writes, [])
     assert.deepStrictEqual(emitted.map(([name]) => name), ['loggingIn'])
+  })
+
+  it('does not parse or dispatch packets after terminal rejection', () => {
+    let parsed = false
+    const state = new LoginState()
+    state.reject()
+    const player = {
+      loginState: state,
+      server: { deserializer: { parsePacketBuffer: () => { parsed = true } } }
+    }
+
+    Player.prototype.readPacket.call(player, Buffer.alloc(0))
+
+    assert.strictEqual(parsed, false)
+    assert.strictEqual(state.phase, LoginPhase.Rejected)
   })
 })

--- a/test/loginVerify.test.js
+++ b/test/loginVerify.test.js
@@ -58,6 +58,10 @@ function createLoginTokens () {
   return { authToken, clientKeys, serviceKeys, skinToken }
 }
 
+function verifyLogin (client, skinToken, multiplayerToken) {
+  return client.verifyLogin({ chain: [], clientDataToken: skinToken, multiplayerToken })
+}
+
 describe('modern login verification', () => {
   it('verifies the OIDC identity token and its bound client-data token', async () => {
     const { authToken, serviceKeys, skinToken } = createLoginTokens()
@@ -65,13 +69,13 @@ describe('modern login verification', () => {
     const client = {}
     LoginVerify(client, null, { offline: false, version: VERSION }, { verifyOidcToken: verifier.verify })
 
-    const result = await client.decodeLoginJWT([], skinToken, authToken)
-    assert.strictEqual(result.userData.extraData.XUID, '2535427801234567')
-    assert.strictEqual(result.userData.extraData.displayName, 'VerifiedPlayer')
-    assert.strictEqual(result.userData.extraData.PlayFabID, 'playfab-player-id')
-    assert.strictEqual(result.userData.extraData.PlayFabTitleID, '20CA2')
-    assert.match(result.userData.extraData.identity, /^[0-9a-f-]{36}$/)
-    assert.strictEqual(result.skinData.ThirdPartyName, 'VerifiedPlayer')
+    const result = await verifyLogin(client, skinToken, authToken)
+    assert.strictEqual(result.identity.XUID, '2535427801234567')
+    assert.strictEqual(result.identity.displayName, 'VerifiedPlayer')
+    assert.strictEqual(result.identity.PlayFabID, 'playfab-player-id')
+    assert.strictEqual(result.identity.PlayFabTitleID, '20CA2')
+    assert.match(result.identity.identity, /^[0-9a-f-]{36}$/)
+    assert.strictEqual(result.clientData.ThirdPartyName, 'VerifiedPlayer')
     assert.deepStrictEqual(result.authentication, {
       authenticated: true,
       method: 'oidc',
@@ -87,7 +91,7 @@ describe('modern login verification', () => {
 
     const parts = authToken.split('.')
     parts[1] = Buffer.from(JSON.stringify({ ...JWT.decode(authToken), xname: 'Impostor' })).toString('base64url')
-    await assert.rejects(client.decodeLoginJWT([], skinToken, parts.join('.')), /invalid signature/)
+    await assert.rejects(verifyLogin(client, skinToken, parts.join('.')), /invalid signature/)
   })
 
   it('rejects client data not signed by the key in the verified identity token', async () => {
@@ -98,7 +102,7 @@ describe('modern login verification', () => {
     const client = {}
     LoginVerify(client, null, { offline: false, version: VERSION }, { verifyOidcToken: verifier.verify })
 
-    await assert.rejects(client.decodeLoginJWT([], forgedSkinToken, authToken), /invalid signature/)
+    await assert.rejects(verifyLogin(client, forgedSkinToken, authToken), /invalid signature/)
   })
 
   it('rejects tokens for a different audience', async () => {
@@ -136,22 +140,22 @@ describe('modern login verification', () => {
     LoginVerify(client, null, { offline: false, version: VERSION }, {
       verifyOidcToken: async () => ({ ...validPayload, xid: undefined })
     })
-    await assert.rejects(client.decodeLoginJWT([], skinToken, authToken), /XUID is invalid/)
+    await assert.rejects(verifyLogin(client, skinToken, authToken), /XUID is invalid/)
 
     LoginVerify(client, null, { offline: false, version: VERSION }, {
       verifyOidcToken: async () => ({ ...validPayload, xname: undefined })
     })
-    await assert.rejects(client.decodeLoginJWT([], skinToken, authToken), /display name/)
+    await assert.rejects(verifyLogin(client, skinToken, authToken), /display name/)
 
     LoginVerify(client, null, { offline: false, version: VERSION }, {
       verifyOidcToken: async () => ({ ...validPayload, exp: undefined })
     })
-    await assert.rejects(client.decodeLoginJWT([], skinToken, authToken), /missing its expiry/)
+    await assert.rejects(verifyLogin(client, skinToken, authToken), /missing its expiry/)
 
     LoginVerify(client, null, { offline: false, version: VERSION }, {
       verifyOidcToken: async () => ({ ...validPayload, iss: undefined })
     })
-    await assert.rejects(client.decodeLoginJWT([], skinToken, authToken), /missing its issuer/)
+    await assert.rejects(verifyLogin(client, skinToken, authToken), /missing its issuer/)
   })
 
   it('rejects a non-P-384 client key in an otherwise verified OIDC payload', async () => {
@@ -162,6 +166,6 @@ describe('modern login verification', () => {
       verifyOidcToken: async () => ({ ...JWT.decode(authToken), cpk: publicKeyBase64(rsa.publicKey) })
     })
 
-    await assert.rejects(client.decodeLoginJWT([], skinToken, authToken), /must be an EC P-384 key/)
+    await assert.rejects(verifyLogin(client, skinToken, authToken), /must be an EC P-384 key/)
   })
 })

--- a/test/loginVerify.test.js
+++ b/test/loginVerify.test.js
@@ -72,6 +72,11 @@ describe('modern login verification', () => {
     assert.strictEqual(result.userData.extraData.PlayFabTitleID, '20CA2')
     assert.match(result.userData.extraData.identity, /^[0-9a-f-]{36}$/)
     assert.strictEqual(result.skinData.ThirdPartyName, 'VerifiedPlayer')
+    assert.deepStrictEqual(result.authentication, {
+      authenticated: true,
+      method: 'oidc',
+      issuer: ISSUER
+    })
   })
 
   it('rejects an identity token with an invalid Microsoft signature', async () => {
@@ -122,5 +127,41 @@ describe('modern login verification', () => {
     })
 
     await assert.rejects(verifier.verify(token, VERSION), /jwt expired/)
+  })
+
+  it('rejects verified OIDC payloads missing required identity claims', async () => {
+    const { authToken, skinToken } = createLoginTokens()
+    const client = {}
+    const validPayload = JWT.decode(authToken)
+    LoginVerify(client, null, { offline: false, version: VERSION }, {
+      verifyOidcToken: async () => ({ ...validPayload, xid: undefined })
+    })
+    await assert.rejects(client.decodeLoginJWT([], skinToken, authToken), /XUID is invalid/)
+
+    LoginVerify(client, null, { offline: false, version: VERSION }, {
+      verifyOidcToken: async () => ({ ...validPayload, xname: undefined })
+    })
+    await assert.rejects(client.decodeLoginJWT([], skinToken, authToken), /display name/)
+
+    LoginVerify(client, null, { offline: false, version: VERSION }, {
+      verifyOidcToken: async () => ({ ...validPayload, exp: undefined })
+    })
+    await assert.rejects(client.decodeLoginJWT([], skinToken, authToken), /missing its expiry/)
+
+    LoginVerify(client, null, { offline: false, version: VERSION }, {
+      verifyOidcToken: async () => ({ ...validPayload, iss: undefined })
+    })
+    await assert.rejects(client.decodeLoginJWT([], skinToken, authToken), /missing its issuer/)
+  })
+
+  it('rejects a non-P-384 client key in an otherwise verified OIDC payload', async () => {
+    const { authToken, skinToken } = createLoginTokens()
+    const rsa = crypto.generateKeyPairSync('rsa', { modulusLength: 2048 })
+    const client = {}
+    LoginVerify(client, null, { offline: false, version: VERSION }, {
+      verifyOidcToken: async () => ({ ...JWT.decode(authToken), cpk: publicKeyBase64(rsa.publicKey) })
+    })
+
+    await assert.rejects(client.decodeLoginJWT([], skinToken, authToken), /must be an EC P-384 key/)
   })
 })

--- a/test/loginVerifyLegacy.test.js
+++ b/test/loginVerifyLegacy.test.js
@@ -55,16 +55,20 @@ function createValidLegacyLogin () {
   }
 }
 
+function verifyLogin (client, chain, clientDataToken, multiplayerToken = '') {
+  return client.verifyLogin({ chain, clientDataToken, multiplayerToken })
+}
+
 describe('legacy login verification', () => {
   it('accepts a complete chain rooted through the pinned Mojang key', async () => {
     const login = createValidLegacyLogin()
     const client = {}
     LoginVerify(client, null, { offline: false, version: VERSION }, { mojangPublicKey: login.mojangPublicKey })
 
-    const result = await client.decodeLoginJWT(login.chain, login.skin)
-    assert.strictEqual(result.key, login.clientPublicKey)
-    assert.deepStrictEqual(result.userData.extraData, login.extraData)
-    assert.strictEqual(result.skinData.ThirdPartyName, login.extraData.displayName)
+    const result = await verifyLogin(client, login.chain, login.skin)
+    assert.strictEqual(result.clientPublicKeyBase64, login.clientPublicKey)
+    assert.deepStrictEqual(result.identity, login.extraData)
+    assert.strictEqual(result.clientData.ThirdPartyName, login.extraData.displayName)
     assert.deepStrictEqual(result.authentication, {
       authenticated: true,
       method: 'legacy',
@@ -93,7 +97,7 @@ describe('legacy login verification', () => {
 
     assert.doesNotThrow(() => JWT.verify(forgedChain[1], attacker.publicKey, { algorithms: ['ES384'] }))
     assert.throws(() => JWT.verify(forgedChain[1], trusted.publicKey, { algorithms: ['ES384'] }), /invalid signature/)
-    await assert.rejects(client.decodeLoginJWT(forgedChain, forgedSkin), /not anchored by Mojang/)
+    await assert.rejects(verifyLogin(client, forgedChain, forgedSkin), /not anchored by Mojang/)
   })
 
   it('stops a forged login before the server handshake and login events', async () => {
@@ -149,8 +153,8 @@ describe('legacy login verification', () => {
     const client = {}
     LoginVerify(client, null, { offline: false, version: VERSION })
 
-    await assert.rejects(client.decodeLoginJWT([selfSigned], skin), /Offline login is not allowed/)
-    await assert.rejects(client.decodeLoginJWT([selfSigned, selfSigned], skin), /Unexpected login chain length/)
+    await assert.rejects(verifyLogin(client, [selfSigned], skin), /Offline login is not allowed/)
+    await assert.rejects(verifyLogin(client, [selfSigned, selfSigned], skin), /Unexpected login chain length/)
   })
 
   it('continues to accept a self-signed one-token chain in offline mode', async () => {
@@ -162,8 +166,8 @@ describe('legacy login verification', () => {
     const client = {}
     LoginVerify(client, null, { offline: true, version: VERSION })
 
-    const result = await client.decodeLoginJWT([chain], skin)
-    assert.deepStrictEqual(result.userData.extraData, extraData)
+    const result = await verifyLogin(client, [chain], skin)
+    assert.deepStrictEqual(result.identity, extraData)
     assert.deepStrictEqual(result.authentication, {
       authenticated: false,
       method: 'offline',
@@ -185,9 +189,9 @@ describe('legacy login verification', () => {
     const client = {}
     LoginVerify(client, null, { offline: true, version: VERSION })
 
-    const result = await client.decodeLoginJWT([oneToken], skin)
-    assert.strictEqual(result.userData.extraData.XUID, '0')
-    await assert.rejects(client.decodeLoginJWT(threeTokens, skin), /not anchored by Mojang/)
+    const result = await verifyLogin(client, [oneToken], skin)
+    assert.strictEqual(result.identity.XUID, '0')
+    await assert.rejects(verifyLogin(client, threeTokens, skin), /not anchored by Mojang/)
   })
 
   it('uses a verified multiplayer token instead of an accompanying legacy chain', async () => {
@@ -204,8 +208,8 @@ describe('legacy login verification', () => {
       verifyOidcToken: value => JWT.verify(value, service.publicKey, { algorithms: ['RS256'] })
     })
 
-    const result = await client.decodeLoginJWT(['deliberately-invalid-legacy-chain'], login.skin, token)
-    assert.strictEqual(result.userData.extraData.displayName, 'OidcPlayer')
+    const result = await verifyLogin(client, ['deliberately-invalid-legacy-chain'], login.skin, token)
+    assert.strictEqual(result.identity.displayName, 'OidcPlayer')
   })
 
   it('rejects handshake and initialization packets before login verification', () => {

--- a/test/loginVerifyLegacy.test.js
+++ b/test/loginVerifyLegacy.test.js
@@ -65,6 +65,11 @@ describe('legacy login verification', () => {
     assert.strictEqual(result.key, login.clientPublicKey)
     assert.deepStrictEqual(result.userData.extraData, login.extraData)
     assert.strictEqual(result.skinData.ThirdPartyName, login.extraData.displayName)
+    assert.deepStrictEqual(result.authentication, {
+      authenticated: true,
+      method: 'legacy',
+      issuer: 'Mojang'
+    })
   })
 
   it('rejects a chain whose x5u text names Mojang but whose signatures are attacker-rooted', async () => {
@@ -159,6 +164,30 @@ describe('legacy login verification', () => {
 
     const result = await client.decodeLoginJWT([chain], skin)
     assert.deepStrictEqual(result.userData.extraData, extraData)
+    assert.deepStrictEqual(result.authentication, {
+      authenticated: false,
+      method: 'offline',
+      issuer: null
+    })
+  })
+
+  it('normalizes self-asserted offline XUIDs and rejects unanchored three-token chains', async () => {
+    const attacker = createKeys()
+    const attackerPublicKey = publicKeyBase64(attacker.publicKey)
+    const extraData = { displayName: 'OfflinePlayer', identity: crypto.randomUUID(), XUID: '9000000000000001' }
+    const oneToken = sign({ identityPublicKey: attackerPublicKey, extraData }, attacker.privateKey, attackerPublicKey)
+    const threeTokens = [
+      sign({ identityPublicKey: attackerPublicKey }, attacker.privateKey, attackerPublicKey),
+      sign({ identityPublicKey: attackerPublicKey }, attacker.privateKey, attackerPublicKey, 'Mojang'),
+      sign({ identityPublicKey: attackerPublicKey, extraData }, attacker.privateKey, attackerPublicKey, 'Mojang')
+    ]
+    const skin = sign({ ThirdPartyName: extraData.displayName }, attacker.privateKey, attackerPublicKey)
+    const client = {}
+    LoginVerify(client, null, { offline: true, version: VERSION })
+
+    const result = await client.decodeLoginJWT([oneToken], skin)
+    assert.strictEqual(result.userData.extraData.XUID, '0')
+    await assert.rejects(client.decodeLoginJWT(threeTokens, skin), /not anchored by Mojang/)
   })
 
   it('uses a verified multiplayer token instead of an accompanying legacy chain', async () => {
@@ -167,6 +196,7 @@ describe('legacy login verification', () => {
     const token = JWT.sign({ cpk: login.clientPublicKey, xid: login.extraData.XUID, xname: 'OidcPlayer' }, service.privateKey, {
       algorithm: 'RS256',
       expiresIn: '5m',
+      issuer: 'https://test.minecraft.invalid/',
       header: { kid: 'test-key', typ: undefined }
     })
     const client = {}

--- a/test/loginVerifyLegacy.test.js
+++ b/test/loginVerifyLegacy.test.js
@@ -6,6 +6,7 @@ const JWT = require('jsonwebtoken')
 const LoginVerify = require('../src/handshake/loginVerify')
 const { Player } = require('../src/serverPlayer')
 const { ClientStatus } = require('../src/connection')
+const { LoginState } = require('../src/auth/loginState')
 
 const VERSION = '1.26.40'
 
@@ -108,9 +109,11 @@ describe('legacy login verification', () => {
     const disconnects = []
     const player = {
       address: 'local-regression-test',
+      loginState: new LoginState(),
       emit: (name, value) => emitted.push([name, value]),
       handleClientProtocolVersion: () => true,
-      disconnect: reason => disconnects.push(reason)
+      disconnect: reason => disconnects.push(reason),
+      rejectLogin: Player.prototype.rejectLogin
     }
     LoginVerify(player, null, { offline: false, version: VERSION })
 
@@ -182,7 +185,7 @@ describe('legacy login verification', () => {
       const disconnects = []
       const player = {
         status: ClientStatus.Authenticating,
-        awaitingClientHandshake: false,
+        loginState: new LoginState(),
         encryptionEnabled: false,
         server: {
           deserializer: {
@@ -193,7 +196,8 @@ describe('legacy login verification', () => {
         write: name => writes.push(name),
         emit: name => emitted.push(name),
         disconnect: reason => disconnects.push(reason),
-        onHandshake: Player.prototype.onHandshake
+        onHandshake: Player.prototype.onHandshake,
+        rejectLogin: Player.prototype.rejectLogin
       }
 
       Player.prototype.readPacket.call(player, Buffer.alloc(0))

--- a/test/loginVerifyLegacy.test.js
+++ b/test/loginVerifyLegacy.test.js
@@ -1,0 +1,206 @@
+/* eslint-env mocha */
+
+const assert = require('assert')
+const crypto = require('crypto')
+const JWT = require('jsonwebtoken')
+const LoginVerify = require('../src/handshake/loginVerify')
+const { Player } = require('../src/serverPlayer')
+const { ClientStatus } = require('../src/connection')
+
+const VERSION = '1.26.40'
+
+function createKeys () {
+  return crypto.generateKeyPairSync('ec', { namedCurve: 'P-384' })
+}
+
+function publicKeyBase64 (key) {
+  return key.export({ format: 'der', type: 'spki' }).toString('base64')
+}
+
+function sign (payload, privateKey, x5u, issuer) {
+  const options = {
+    algorithm: 'ES384',
+    noTimestamp: true,
+    header: { x5u, typ: undefined }
+  }
+  if (issuer) options.issuer = issuer
+  return JWT.sign(payload, privateKey, options)
+}
+
+function createValidLegacyLogin () {
+  const client = createKeys()
+  const mojang = createKeys()
+  const intermediate = createKeys()
+  const clientPublicKey = publicKeyBase64(client.publicKey)
+  const mojangPublicKey = publicKeyBase64(mojang.publicKey)
+  const intermediatePublicKey = publicKeyBase64(intermediate.publicKey)
+  const extraData = {
+    displayName: 'VerifiedLegacyPlayer',
+    identity: crypto.randomUUID(),
+    XUID: '2535427801234567'
+  }
+
+  return {
+    chain: [
+      sign({ certificateAuthority: true, identityPublicKey: mojangPublicKey }, client.privateKey, clientPublicKey),
+      sign({ certificateAuthority: true, identityPublicKey: intermediatePublicKey }, mojang.privateKey, 'untrusted-header-value', 'Mojang'),
+      sign({ extraData, identityPublicKey: clientPublicKey }, intermediate.privateKey, 'untrusted-header-value', 'Mojang')
+    ],
+    client,
+    clientPublicKey,
+    extraData,
+    mojangPublicKey,
+    skin: sign({ ThirdPartyName: extraData.displayName }, client.privateKey, clientPublicKey)
+  }
+}
+
+describe('legacy login verification', () => {
+  it('accepts a complete chain rooted through the pinned Mojang key', async () => {
+    const login = createValidLegacyLogin()
+    const client = {}
+    LoginVerify(client, null, { offline: false, version: VERSION }, { mojangPublicKey: login.mojangPublicKey })
+
+    const result = await client.decodeLoginJWT(login.chain, login.skin)
+    assert.strictEqual(result.key, login.clientPublicKey)
+    assert.deepStrictEqual(result.userData.extraData, login.extraData)
+    assert.strictEqual(result.skinData.ThirdPartyName, login.extraData.displayName)
+  })
+
+  it('rejects a chain whose x5u text names Mojang but whose signatures are attacker-rooted', async () => {
+    const attacker = createKeys()
+    const trusted = createKeys()
+    const attackerPublicKey = publicKeyBase64(attacker.publicKey)
+    const trustedPublicKey = publicKeyBase64(trusted.publicKey)
+    const extraData = {
+      displayName: 'Impostor',
+      identity: crypto.randomUUID(),
+      XUID: '9000000000000001'
+    }
+    const forgedChain = [
+      sign({ certificateAuthority: true, identityPublicKey: attackerPublicKey }, attacker.privateKey, attackerPublicKey),
+      sign({ certificateAuthority: true, identityPublicKey: attackerPublicKey }, attacker.privateKey, trustedPublicKey, 'Mojang'),
+      sign({ extraData, identityPublicKey: attackerPublicKey }, attacker.privateKey, trustedPublicKey, 'Mojang')
+    ]
+    const forgedSkin = sign({ ThirdPartyName: extraData.displayName }, attacker.privateKey, attackerPublicKey)
+    const client = {}
+    LoginVerify(client, null, { offline: false, version: VERSION }, { mojangPublicKey: trustedPublicKey })
+
+    assert.doesNotThrow(() => JWT.verify(forgedChain[1], attacker.publicKey, { algorithms: ['ES384'] }))
+    assert.throws(() => JWT.verify(forgedChain[1], trusted.publicKey, { algorithms: ['ES384'] }), /invalid signature/)
+    await assert.rejects(client.decodeLoginJWT(forgedChain, forgedSkin), /not anchored by Mojang/)
+  })
+
+  it('stops a forged login before the server handshake and login events', async () => {
+    const attacker = createKeys()
+    const attackerPublicKey = publicKeyBase64(attacker.publicKey)
+    const extraData = {
+      displayName: 'Impostor',
+      identity: crypto.randomUUID(),
+      XUID: '9000000000000001'
+    }
+    const forgedChain = [
+      sign({ certificateAuthority: true, identityPublicKey: attackerPublicKey }, attacker.privateKey, attackerPublicKey),
+      sign({ certificateAuthority: true, identityPublicKey: attackerPublicKey }, attacker.privateKey, attackerPublicKey, 'Mojang'),
+      sign({ extraData, identityPublicKey: attackerPublicKey }, attacker.privateKey, attackerPublicKey, 'Mojang')
+    ]
+    const skin = sign({ ThirdPartyName: extraData.displayName }, attacker.privateKey, attackerPublicKey)
+    const emitted = []
+    const disconnects = []
+    const player = {
+      address: 'local-regression-test',
+      emit: (name, value) => emitted.push([name, value]),
+      handleClientProtocolVersion: () => true,
+      disconnect: reason => disconnects.push(reason)
+    }
+    LoginVerify(player, null, { offline: false, version: VERSION })
+
+    await Player.prototype.onLogin.call(player, {
+      data: {
+        params: {
+          protocol_version: 0,
+          tokens: {
+            identity: JSON.stringify({ Certificate: JSON.stringify({ chain: forgedChain }) }),
+            client: skin
+          }
+        }
+      }
+    })
+
+    assert.deepStrictEqual(disconnects, ['Server authentication error'])
+    assert.deepStrictEqual(emitted.map(([name]) => name), ['loggingIn'])
+  })
+
+  it('rejects self-signed and malformed chains when authentication is enabled', async () => {
+    const attacker = createKeys()
+    const attackerPublicKey = publicKeyBase64(attacker.publicKey)
+    const selfSigned = sign({
+      identityPublicKey: attackerPublicKey,
+      extraData: { displayName: 'Impostor', identity: crypto.randomUUID(), XUID: '1' }
+    }, attacker.privateKey, attackerPublicKey)
+    const skin = sign({ ThirdPartyName: 'Impostor' }, attacker.privateKey, attackerPublicKey)
+    const client = {}
+    LoginVerify(client, null, { offline: false, version: VERSION })
+
+    await assert.rejects(client.decodeLoginJWT([selfSigned], skin), /three-token chain/)
+    await assert.rejects(client.decodeLoginJWT([selfSigned, selfSigned], skin), /Unexpected login chain length/)
+  })
+
+  it('continues to accept a self-signed one-token chain in offline mode', async () => {
+    const local = createKeys()
+    const localPublicKey = publicKeyBase64(local.publicKey)
+    const extraData = { displayName: 'OfflinePlayer', identity: crypto.randomUUID(), XUID: '0' }
+    const chain = sign({ identityPublicKey: localPublicKey, extraData }, local.privateKey, localPublicKey)
+    const skin = sign({ ThirdPartyName: extraData.displayName }, local.privateKey, localPublicKey)
+    const client = {}
+    LoginVerify(client, null, { offline: true, version: VERSION })
+
+    const result = await client.decodeLoginJWT([chain], skin)
+    assert.deepStrictEqual(result.userData.extraData, extraData)
+  })
+
+  it('uses a verified multiplayer token instead of an accompanying legacy chain', async () => {
+    const login = createValidLegacyLogin()
+    const service = crypto.generateKeyPairSync('rsa', { modulusLength: 2048 })
+    const token = JWT.sign({ cpk: login.clientPublicKey, xid: login.extraData.XUID, xname: 'OidcPlayer' }, service.privateKey, {
+      algorithm: 'RS256',
+      header: { kid: 'test-key', typ: undefined }
+    })
+    const client = {}
+    LoginVerify(client, null, { offline: false, version: VERSION }, {
+      verifyOidcToken: value => JWT.verify(value, service.publicKey, { algorithms: ['RS256'] })
+    })
+
+    const result = await client.decodeLoginJWT(['deliberately-invalid-legacy-chain'], login.skin, token)
+    assert.strictEqual(result.userData.extraData.displayName, 'OidcPlayer')
+  })
+
+  it('rejects handshake and initialization packets before login verification', () => {
+    for (const packetName of ['client_to_server_handshake', 'set_local_player_as_initialized']) {
+      const writes = []
+      const emitted = []
+      const disconnects = []
+      const player = {
+        status: ClientStatus.Authenticating,
+        awaitingClientHandshake: false,
+        encryptionEnabled: false,
+        server: {
+          deserializer: {
+            parsePacketBuffer: () => ({ data: { name: packetName, params: {} } })
+          }
+        },
+        connection: { address: 'local-regression-test' },
+        write: name => writes.push(name),
+        emit: name => emitted.push(name),
+        disconnect: reason => disconnects.push(reason),
+        onHandshake: Player.prototype.onHandshake
+      }
+
+      Player.prototype.readPacket.call(player, Buffer.alloc(0))
+
+      assert.strictEqual(player.status, ClientStatus.Authenticating)
+      assert.deepStrictEqual(writes, [])
+      assert.deepStrictEqual(emitted, [])
+      assert.deepStrictEqual(disconnects, ['Server authentication error'])
+    }
+  })
+})

--- a/test/loginVerifyLegacy.test.js
+++ b/test/loginVerifyLegacy.test.js
@@ -141,7 +141,7 @@ describe('legacy login verification', () => {
     const client = {}
     LoginVerify(client, null, { offline: false, version: VERSION })
 
-    await assert.rejects(client.decodeLoginJWT([selfSigned], skin), /three-token chain/)
+    await assert.rejects(client.decodeLoginJWT([selfSigned], skin), /Offline login is not allowed/)
     await assert.rejects(client.decodeLoginJWT([selfSigned, selfSigned], skin), /Unexpected login chain length/)
   })
 
@@ -163,6 +163,7 @@ describe('legacy login verification', () => {
     const service = crypto.generateKeyPairSync('rsa', { modulusLength: 2048 })
     const token = JWT.sign({ cpk: login.clientPublicKey, xid: login.extraData.XUID, xname: 'OidcPlayer' }, service.privateKey, {
       algorithm: 'RS256',
+      expiresIn: '5m',
       header: { kid: 'test-key', typ: undefined }
     })
     const client = {}


### PR DESCRIPTION
## Summary

Refactors the server login and encryption handshake into an explicit, fail-closed sequence.

This fixes authentication trust and state-ordering issues in the legacy JWT login path and prevents clients from momentarily advancing through the handshake before authentication completes.

## Changes

- Verify legacy JWT chains through cryptographic key transitions rooted at Mojang’s pinned key.
- Require the expected legacy chain shape, algorithms, issuers, identity claims, and P-384 keys.
- Keep verified OIDC multiplayer tokens authoritative when present.
- Bind the client-data token to the client key established by the verified identity.
- Return explicit authentication metadata:
  - `authenticated`
  - `method`: `oidc`, `legacy`, or `offline`
  - `issuer`
- Normalize unauthenticated/offline XUIDs to `0`.
- Introduce explicit login phases:
  - awaiting login
  - verifying login
  - awaiting encrypted handshake
  - complete
  - rejected
  - closed
- Reject duplicate, premature, and out-of-order login/handshake packets.
- Make authentication rejection terminal before the delayed transport close.
- Verify the self-signed server handshake JWT before deriving encryption material.
- Generate a fresh handshake salt for every connection.
- Document and type the authentication result exposed on `Player` and the `login` event.

## Event semantics

- `loggingIn`: raw, unverified login notification.
- `login`: identity and client-data verification succeeded.
- `join`: the encrypted client handshake completed.
- `spawn`: client initialization completed.

## API

The `login` event retains its existing `user` value and adds an `authentication` result. `Player.authentication` exposes the same result.

Offline clients remain supported when the server is configured with `offline: true`, but self-asserted XUIDs are no longer exposed as trusted identities.