### PR TITLE
test: fix port-bind race in proxy tests

### DIFF
--- a/test/proxy.js
+++ b/test/proxy.js
@@ -4,63 +4,68 @@ const { getPort } = require('./util')
 
 function proxyTest (version, raknetBackend = 'raknet-native', timeout = 1000 * 40) {
   console.log('with raknet backend', raknetBackend)
-  return waitFor(async res => {
-    const SERVER_PORT = await getPort()
-    const CLIENT_PORT = await getPort()
-    const server = new Server({
-      host: '0.0.0.0', // optional
-      port: SERVER_PORT, // optional
-      offline: true,
-      raknetBackend,
-      version // The server version
-    })
-    await server.listen()
-
-    server.on('connect', client => {
-      console.debug('Client has connected')
-      client.on('join', () => { // The client has joined the server.
-        console.debug('Client has authenticated')
-        setTimeout(() => {
-          client.disconnect('Hello world !')
-        }, 500) // allow some time for client to connect
-      })
-    })
-
-    console.debug('Server started', server.options.version)
-    await new Promise(resolve => setTimeout(resolve, 500))
-
-    const relay = new Relay({
-      version,
-      offline: true,
-      /* host and port for clients to listen to */
-      host: '0.0.0.0',
-      port: CLIENT_PORT,
-      /* Where to send upstream packets to */
-      destination: {
-        host: '127.0.0.1',
-        port: SERVER_PORT
-      },
-      raknetBackend
-    })
-    relay.conLog = console.debug
-    await relay.listen()
-
-    console.debug('Proxy started', server.options.version)
-    await new Promise(resolve => setTimeout(resolve, 500))
-
-    const client = createClient({ host: '127.0.0.1', port: CLIENT_PORT, version, username: 'Boat', offline: true, raknetBackend, skipPing: true })
-    console.debug('Client started')
-    client.on('error', console.log)
-    client.on('packet', console.log)
-    client.on('disconnect', packet => {
-      console.assert(packet.message === 'Hello world !')
-
-      server.close()
-      relay.close()
-      console.log('✔ OK')
-      sleep(200).then(res)
-    })
+  return waitFor((res, rej) => {
+    // Propagate errors (like a failed port bind) so mocha can fail fast and retry with fresh ports
+    startProxyTest(version, raknetBackend, res).catch(rej)
   }, timeout, () => { throw Error('timed out') })
+}
+
+async function startProxyTest (version, raknetBackend, res) {
+  const SERVER_PORT = await getPort()
+  const CLIENT_PORT = await getPort()
+  const server = new Server({
+    host: '0.0.0.0', // optional
+    port: SERVER_PORT, // optional
+    offline: true,
+    raknetBackend,
+    version // The server version
+  })
+  await server.listen()
+
+  server.on('connect', client => {
+    console.debug('Client has connected')
+    client.on('join', () => { // The client has joined the server.
+      console.debug('Client has authenticated')
+      setTimeout(() => {
+        client.disconnect('Hello world !')
+      }, 500) // allow some time for client to connect
+    })
+  })
+
+  console.debug('Server started', server.options.version)
+  await new Promise(resolve => setTimeout(resolve, 500))
+
+  const relay = new Relay({
+    version,
+    offline: true,
+    /* host and port for clients to listen to */
+    host: '0.0.0.0',
+    port: CLIENT_PORT,
+    /* Where to send upstream packets to */
+    destination: {
+      host: '127.0.0.1',
+      port: SERVER_PORT
+    },
+    raknetBackend
+  })
+  relay.conLog = console.debug
+  await relay.listen()
+
+  console.debug('Proxy started', server.options.version)
+  await new Promise(resolve => setTimeout(resolve, 500))
+
+  const client = createClient({ host: '127.0.0.1', port: CLIENT_PORT, version, username: 'Boat', offline: true, raknetBackend, skipPing: true })
+  console.debug('Client started')
+  client.on('error', console.log)
+  client.on('packet', console.log)
+  client.on('disconnect', packet => {
+    console.assert(packet.message === 'Hello world !')
+
+    server.close()
+    relay.close()
+    console.log('✔ OK')
+    sleep(200).then(res)
+  })
 }
 
 // if (!module.parent) { proxyTest('1.16.220', 'raknet-native') }

--- a/test/util.js
+++ b/test/util.js
@@ -1,11 +1,14 @@
-const net = require('net')
+const dgram = require('dgram')
 
-const getPort = () => new Promise(resolve => {
-  const server = net.createServer()
-  server.listen(0, '127.0.0.1')
-  server.on('listening', () => {
-    const { port } = server.address()
-    server.close(() => {
+// The tests bind UDP servers, so probe for a free port over UDP too: a port
+// that is free for TCP can still be unavailable for UDP (notably on Windows,
+// which reserves excluded port ranges per protocol).
+const getPort = () => new Promise((resolve, reject) => {
+  const socket = dgram.createSocket('udp4')
+  socket.once('error', reject)
+  socket.bind(0, () => {
+    const { port } = socket.address()
+    socket.close(() => {
       // Wait a bit for port to free as we try to bind right after freeing it
       setTimeout(() => {
         resolve(port)


### PR DESCRIPTION
## Problem

The proxy tests are flaky on windows-latest. In [this CI run](https://github.com/PrismarineJS/bedrock-protocol/actions/runs/33336209878/job/99323445974), `proxies 1.16.201` failed with `Error: timed out` even with `--retries 2` — all three attempts logged `Failed to bind server on [0.0.0.0]/<port>, is the port free?` (ports 55314, 55335, 55351) and then each hung for the full 40s timeout.

Two bugs combined to cause this:

1. **TCP/UDP port mismatch in `getPort()`.** `test/util.js` finds a "free" port by binding a TCP `net` server to port 0, but the raknet servers bind **UDP**. A port that is free for TCP is not necessarily free (or allowed) for UDP — notably on Windows, which reserves excluded port ranges per protocol (Hyper-V/WinNAT), so consecutive TCP-allocated ephemeral ports can all land in a UDP-excluded range. That's why every retry failed the same way.

2. **Bind failures were swallowed.** `waitFor()` calls its callback without consuming the promise an async callback returns, so when `server.listen()` threw, the rejection went nowhere and the test sat until the 40s timeout instead of failing fast — turning what should have been a quick retry with fresh ports into a guaranteed `timed out` failure.

## Fix

- `test/util.js`: probe for a free port with a `dgram` (UDP) socket, matching what raknet actually binds.
- `test/proxy.js`: move the test body into an async function and wire it through `waitFor((res, rej) => startProxyTest(...).catch(rej))` — the same pattern `test/internal.js` already uses — so a failed bind rejects immediately with the real error and mocha's `--retries 2` can retry with fresh ports.

Verified locally that an occupied port now rejects the test in ~300ms with `bind EADDRINUSE` instead of hanging 40s with `timed out`.